### PR TITLE
Feature/ab#32463 semantic caching ai reporting

### DIFF
--- a/applications/Unity.AI.Reporting.Backend/requirements.txt
+++ b/applications/Unity.AI.Reporting.Backend/requirements.txt
@@ -7,5 +7,6 @@ langchain-postgres==0.0.17
 psycopg==3.3.2
 PyJWT==2.12.1
 python-dotenv==1.2.1
+rapidfuzz>=3.13.0
 requests==2.33.1
 tiktoken==0.12.0

--- a/applications/Unity.AI.Reporting.Backend/src/api.py
+++ b/applications/Unity.AI.Reporting.Backend/src/api.py
@@ -422,7 +422,7 @@ def ask():
         # ── Semantic cache lookup ────────────────────────────────────────────
         cache_hit = None
         query_embedding = None
-        normalized_query = question.strip().lower()
+        normalized_query = cache_reranker.normalize_query(question)
 
         if config.app.semantic_cache_enabled and not is_retry:
             # Layer 1: exact match (no embedding cost)
@@ -451,16 +451,22 @@ def ask():
                             f"score={fuzzy_match['score']:.1f}"
                         )
 
-            # Layer 2: semantic similarity
+            # Layer 2: dense embedding — top-K with borderline zone floor
             if not cache_hit:
                 loop = asyncio.get_event_loop()
                 query_embedding = await loop.run_in_executor(
                     None, embedding_manager.embed_query, normalized_query
                 )
-                cache_hit = cache_repository.find_similar(
+                candidates = cache_repository.find_similar_topk(
                     tenant_id, db_id, schema_types, collection_name,
-                    query_embedding, config.app.semantic_cache_threshold
+                    query_embedding,
+                    threshold=config.app.semantic_cache_borderline_low,
+                    k=config.app.semantic_cache_top_k
                 )
+                # Direct accept: best candidate clears the high-confidence threshold
+                # Borderline zone [0.85, 0.95) is reserved for Phase 3 LLM judge
+                if candidates and candidates[0]["similarity"] >= config.app.semantic_cache_threshold:
+                    cache_hit = candidates[0]
 
             if cache_hit:
                 cached = cache_hit["response_payload"]
@@ -485,11 +491,6 @@ def ask():
                     hit_type = cache_hit.get("hit_type_override") or (
                         "exact_hit" if cache_hit["similarity"] == 1.0 else "semantic_hit"
                     )
-                    if hit_type == "semantic_hit":
-                        logger.info(
-                            f"[cache:semantic_hit] tenant={tenant_id} db={db_id} "
-                            f"similarity={cache_hit['similarity']:.4f}"
-                        )
                     tokens_saved = cached.get("tokens", {}).get("total_tokens", 0)
                     initial_viz_settings = {}
                     if "map" in cached.get("visualization_options", []):
@@ -502,11 +503,19 @@ def ask():
                         visualization_settings=initial_viz_settings
                     )
                     cache_repository.touch(cache_hit["cache_id"])
-                    logger.info(
-                        f"[cache:{hit_type}] tenant={tenant_id} db={db_id} "
-                        f"similarity={cache_hit['similarity']:.4f} "
-                        f"tokens_saved={tokens_saved}"
-                    )
+                    if hit_type == "semantic_hit":
+                        logger.info(
+                            f"[cache:semantic_hit] tenant={tenant_id} db={db_id} "
+                            f"similarity={cache_hit['similarity']:.4f} "
+                            f"threshold={config.app.semantic_cache_threshold} "
+                            f"tokens_saved={tokens_saved}"
+                        )
+                    else:
+                        logger.info(
+                            f"[cache:{hit_type}] tenant={tenant_id} db={db_id} "
+                            f"similarity={cache_hit['similarity']:.4f} "
+                            f"tokens_saved={tokens_saved}"
+                        )
                     return jsonify({
                         "card_id": card_id,
                         "x_field": cached.get("x_field", []),

--- a/applications/Unity.AI.Reporting.Backend/src/api.py
+++ b/applications/Unity.AI.Reporting.Backend/src/api.py
@@ -549,7 +549,7 @@ def ask():
                         "tokens": sql_tokens,
                     }
                 )
-                cache_repository.ensure_ivfflat_index()
+                cache_repository.ensure_hnsw_index()
                 logger.info(
                     f"Cache stored: tenant={tenant_id} "
                     f"tokens={sql_tokens.get('total_tokens', 0)}"

--- a/applications/Unity.AI.Reporting.Backend/src/api.py
+++ b/applications/Unity.AI.Reporting.Backend/src/api.py
@@ -384,6 +384,210 @@ def get_feedback_for_admin():
         logger.error(f"Error retrieving feedback: {e}", exc_info=True)
         return jsonify({"error": "Failed to retrieve feedback"}), 500
 
+def _build_viz_settings(visualization_options: list) -> dict:
+    """Return Metabase visualization settings dict for the given options list."""
+    if "map" in visualization_options:
+        return {"map.region": os.getenv("MB_MAP_REGION_UUID", "1c5d50ee-4389-4593-37c1-fa8d4687ff4c")}
+    return {}
+
+
+async def _fuzzy_cache_lookup(tenant_id, db_id, schema_types, collection_name, normalized_query):
+    """Layer 1.5: rapidfuzz match against recent normalized queries."""
+    recent = cache_repository.get_recent_normalized_queries(
+        tenant_id, db_id, schema_types, collection_name, config.app.fuzzy_match_limit
+    )
+    fuzzy_match = cache_reranker.fuzzy_matcher.find_best(
+        normalized_query, recent, config.app.fuzzy_match_threshold
+    )
+    if not fuzzy_match:
+        return None
+    cache_hit = cache_repository.find_exact(
+        tenant_id, db_id, schema_types, collection_name, fuzzy_match["normalized_query"]
+    )
+    if cache_hit:
+        cache_hit["hit_type_override"] = "fuzzy_hit"
+        logger.info(
+            f"[cache:fuzzy_hit] tenant={tenant_id} db={db_id} score={fuzzy_match['score']:.1f}"
+        )
+    return cache_hit
+
+
+async def _llm_judge_lookup(tenant_id, db_id, normalized_query, borderline):
+    """Run LLM judge over borderline candidates in parallel; return the best hit or None."""
+    borderline_sims = ', '.join(f"{c['similarity']:.4f}" for c in borderline)
+    logger.info(
+        f"[cache:borderline] tenant={tenant_id} db={db_id} "
+        f"count={len(borderline)} similarities=[{borderline_sims}]"
+    )
+    async with aiohttp.ClientSession() as judge_session:
+        results = await asyncio.gather(*[
+            cache_reranker.llm_judge.score_candidate(
+                normalized_query, candidate["query_text"], judge_session, config.ai
+            )
+            for candidate in borderline
+        ])
+
+    best_candidate, best_score = None, -1  # sentinel; valid scores are 0..10
+    for candidate, (score, judge_tokens) in zip(borderline, results):
+        logger.info(
+            f"[cache:llm_judge] tenant={tenant_id} db={db_id} "
+            f"similarity={candidate['similarity']:.4f} score={score} tokens={judge_tokens}"
+        )
+        is_better_score = score > best_score
+        is_tiebreak = (score == best_score and best_candidate is not None
+                       and candidate["similarity"] > best_candidate["similarity"])
+        if is_better_score or is_tiebreak:
+            best_score, best_candidate = score, candidate
+
+    if best_candidate is not None and best_score >= config.app.llm_judge_score_threshold:
+        best_candidate["hit_type_override"] = "llm_judge_hit"
+        logger.info(
+            f"[cache:llm_judge_selected] tenant={tenant_id} db={db_id} "
+            f"score={best_score} similarity={best_candidate['similarity']:.4f} "
+            f"threshold={config.app.llm_judge_score_threshold}"
+        )
+        return best_candidate
+
+    logger.info(
+        f"[cache:llm_judge_miss] tenant={tenant_id} db={db_id} "
+        f"best_score={best_score} threshold={config.app.llm_judge_score_threshold}"
+    )
+    return None
+
+
+async def _embedding_cache_lookup(tenant_id, db_id, schema_types, collection_name, normalized_query):
+    """Layer 2: dense embedding top-K search with optional LLM judge for borderline zone.
+
+    Returns (cache_hit_or_None, query_embedding).
+    """
+    loop = asyncio.get_event_loop()
+    query_embedding = await loop.run_in_executor(
+        None, embedding_manager.embed_query, normalized_query
+    )
+    candidates = cache_repository.find_similar_topk(
+        tenant_id, db_id, schema_types, collection_name,
+        query_embedding,
+        threshold=config.app.semantic_cache_borderline_low,
+        k=config.app.semantic_cache_top_k,
+    )
+    if candidates:
+        candidate_sims = ', '.join(f"{c['similarity']:.4f}" for c in candidates)
+        logger.info(
+            f"[cache:candidates] tenant={tenant_id} db={db_id} "
+            f"count={len(candidates)} similarities=[{candidate_sims}]"
+        )
+
+    if candidates and candidates[0]["similarity"] >= config.app.semantic_cache_threshold:
+        return candidates[0], query_embedding
+
+    if candidates and config.app.llm_judge_enabled:
+        borderline = [c for c in candidates if c["similarity"] < config.app.semantic_cache_threshold]
+        if borderline:
+            cache_hit = await _llm_judge_lookup(tenant_id, db_id, normalized_query, borderline)
+            return cache_hit, query_embedding
+
+    return None, query_embedding
+
+
+async def _semantic_cache_lookup(tenant_id, db_id, schema_types, collection_name, normalized_query):
+    """Orchestrate all three cache layers; return (cache_hit_or_None, query_embedding_or_None)."""
+    cache_hit = cache_repository.find_exact(
+        tenant_id, db_id, schema_types, collection_name, normalized_query
+    )
+    if cache_hit:
+        return cache_hit, None
+
+    if config.app.fuzzy_match_enabled:
+        cache_hit = await _fuzzy_cache_lookup(tenant_id, db_id, schema_types, collection_name, normalized_query)
+        if cache_hit:
+            return cache_hit, None
+
+    return await _embedding_cache_lookup(tenant_id, db_id, schema_types, collection_name, normalized_query)
+
+
+async def _serve_cache_hit(cache_hit, db_id, collection_id, tenant_id):
+    """Validate cached SQL and build the cache-hit response. Returns None if SQL is no longer valid."""
+    cached = cache_hit["response_payload"]
+    try:
+        loop = asyncio.get_event_loop()
+        is_valid, _ = await loop.run_in_executor(
+            None, lambda: metabase_client.validate_sql(cached["sql"], db_id, tenant_id)
+        )
+    except Exception:
+        is_valid = False
+
+    if not is_valid:
+        logger.info(
+            f"[cache:rejected] tenant={tenant_id} db={db_id} "
+            f"similarity={cache_hit['similarity']:.4f} reason=sql_validation_failed"
+        )
+        return None
+
+    hit_type = cache_hit.get("hit_type_override") or (
+        "exact_hit" if cache_hit["similarity"] >= 1.0 else "semantic_hit"
+    )
+    tokens_saved = cached.get("tokens", {}).get("total_tokens", 0)
+    card_id = metabase_client.create_card(
+        cached["sql"], db_id, collection_id, cached["title"],
+        tenant_id=tenant_id,
+        visualization_settings=_build_viz_settings(cached.get("visualization_options", [])),
+    )
+    cache_repository.touch(cache_hit["cache_id"])
+
+    if hit_type == "semantic_hit":
+        logger.info(
+            f"[cache:semantic_hit] tenant={tenant_id} db={db_id} "
+            f"similarity={cache_hit['similarity']:.4f} "
+            f"threshold={config.app.semantic_cache_threshold} tokens_saved={tokens_saved}"
+        )
+    else:
+        logger.info(
+            f"[cache:{hit_type}] tenant={tenant_id} db={db_id} "
+            f"similarity={cache_hit['similarity']:.4f} tokens_saved={tokens_saved}"
+        )
+
+    return jsonify({
+        "card_id": card_id,
+        "x_field": cached.get("x_field", []),
+        "y_field": cached.get("y_field", []),
+        "title": cached["title"],
+        "visualization_options": cached.get("visualization_options", []),
+        "SQL": cached["sql"],
+        "tokens": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+        "from_cache": True,
+        "cache_similarity": round(cache_hit["similarity"], 4),
+        "cache_hit_type": hit_type,
+        "cache_original_query": cache_hit.get("query_text", "") if hit_type == "llm_judge_hit" else None,
+    }), 200
+
+
+async def _store_query_cache(tenant_id, db_id, schema_types, collection_name,
+                             question, normalized_query, query_embedding, sql, metadata, sql_tokens):
+    """Persist a successful SQL generation result to the semantic cache (non-fatal)."""
+    try:
+        if query_embedding is None:
+            loop = asyncio.get_event_loop()
+            query_embedding = await loop.run_in_executor(
+                None, embedding_manager.embed_query, normalized_query
+            )
+        cache_repository.save(
+            tenant_id, db_id, schema_types, collection_name,
+            question, normalized_query, query_embedding,
+            {
+                "sql": sql,
+                "title": metadata.get("title", "Untitled"),
+                "x_field": metadata.get("x_axis", []),
+                "y_field": metadata.get("y_axis", []),
+                "visualization_options": metadata.get("visualization_options", []),
+                "tokens": sql_tokens,
+            },
+        )
+        cache_repository.ensure_hnsw_index()
+        logger.info(f"Cache stored: tenant={tenant_id} tokens={sql_tokens.get('total_tokens', 0)}")
+    except Exception as cache_err:
+        logger.warning(f"Cache store failed (non-fatal): {cache_err}")
+
+
 @app.route("/api/ask", methods=["POST"])
 @require_auth
 def ask():
@@ -393,21 +597,18 @@ def ask():
     """
     data = request.get_json()
     user_data = get_user_from_token()
-    
+
     async def async_ask():
         question = data.get("question")
         conversation = data.get("conversation", [])
         is_retry = bool(data.get("is_retry", False))
         retry_error_type = data.get("retry_error_type") or None
         retry_error_detail = data.get("retry_error_detail") or None
-
-        # Extract user context from JWT token
         tenant_id = user_data["tenant"]
 
         if not question:
             return abort(400, "question is required")
 
-        # Get tenant configuration
         tenant_config = config.get_tenant_config(tenant_id)
         db_id = tenant_config["db_id"]
         collection_id = tenant_config["collection_id"]
@@ -416,191 +617,26 @@ def ask():
 
         logger.info(f"Request - Tenant: {tenant_id}, DB: {db_id}, Collection: {collection_id}")
 
-        # Extract past questions from conversation
         past_questions = chat_manager.extract_past_questions(conversation)
         logger.debug(f"Extracted {len(past_questions)} past questions")
 
-        # ── Semantic cache lookup ────────────────────────────────────────────
-        cache_hit = None
-        query_embedding = None
         normalized_query = cache_reranker.normalize_query(question)
+        query_embedding = None
 
+        # ── Semantic cache lookup ────────────────────────────────────────────
         if config.app.semantic_cache_enabled and not is_retry:
-            # Layer 1: exact match (no embedding cost)
-            cache_hit = cache_repository.find_exact(
+            cache_hit, query_embedding = await _semantic_cache_lookup(
                 tenant_id, db_id, schema_types, collection_name, normalized_query
             )
-
-            # Layer 1.5: fuzzy match 
-            if not cache_hit and config.app.fuzzy_match_enabled:
-                recent = cache_repository.get_recent_normalized_queries(
-                    tenant_id, db_id, schema_types, collection_name,
-                    config.app.fuzzy_match_limit
-                )
-                fuzzy_match = cache_reranker.fuzzy_matcher.find_best(
-                    normalized_query, recent, config.app.fuzzy_match_threshold
-                )
-                if fuzzy_match:
-                    cache_hit = cache_repository.find_exact(
-                        tenant_id, db_id, schema_types, collection_name,
-                        fuzzy_match["normalized_query"]
-                    )
-                    if cache_hit:
-                        cache_hit["hit_type_override"] = "fuzzy_hit"
-                        logger.info(
-                            f"[cache:fuzzy_hit] tenant={tenant_id} db={db_id} "
-                            f"score={fuzzy_match['score']:.1f}"
-                        )
-
-            # Layer 2: dense embedding — top-K with borderline zone floor
-            if not cache_hit:
-                loop = asyncio.get_event_loop()
-                query_embedding = await loop.run_in_executor(
-                    None, embedding_manager.embed_query, normalized_query
-                )
-                candidates = cache_repository.find_similar_topk(
-                    tenant_id, db_id, schema_types, collection_name,
-                    query_embedding,
-                    threshold=config.app.semantic_cache_borderline_low,
-                    k=config.app.semantic_cache_top_k
-                )
-                if candidates:
-                    candidate_sims = ', '.join(f"{c['similarity']:.4f}" for c in candidates)
-                    logger.info(
-                        f"[cache:candidates] tenant={tenant_id} db={db_id} "
-                        f"count={len(candidates)} "
-                        f"similarities=[{candidate_sims}]"
-                    )
-                # Direct accept: best candidate clears the high-confidence threshold
-                if candidates and candidates[0]["similarity"] >= config.app.semantic_cache_threshold:
-                    cache_hit = candidates[0]
-
-                # Borderline zone [borderline_low, threshold): score ALL candidates in parallel, pick best above threshold
-                if not cache_hit and candidates and config.app.llm_judge_enabled:
-                    borderline = [
-                        c for c in candidates
-                        if c["similarity"] < config.app.semantic_cache_threshold
-                    ]
-                    if borderline:
-                        borderline_sims = ', '.join(f"{c['similarity']:.4f}" for c in borderline)
-                        logger.info(
-                            f"[cache:borderline] tenant={tenant_id} db={db_id} "
-                            f"count={len(borderline)} "
-                            f"similarities=[{borderline_sims}]"
-                        )
-                        async with aiohttp.ClientSession() as judge_session:
-                            results = await asyncio.gather(*[
-                                cache_reranker.llm_judge.score_candidate(
-                                    normalized_query,
-                                    candidate["query_text"],
-                                    judge_session,
-                                    config.ai,
-                                )
-                                for candidate in borderline
-                            ])
-
-                        best_candidate = None
-                        best_score = -1  # sentinel; valid scores are 0..10
-                        for candidate, (score, judge_tokens) in zip(borderline, results):
-                            logger.info(
-                                f"[cache:llm_judge] tenant={tenant_id} db={db_id} "
-                                f"similarity={candidate['similarity']:.4f} "
-                                f"score={score} "
-                                f"tokens={judge_tokens}"
-                            )
-                            if score > best_score or (
-                                score == best_score
-                                and best_candidate is not None
-                                and candidate["similarity"] > best_candidate["similarity"]
-                            ):
-                                best_score = score
-                                best_candidate = candidate
-
-                        if best_candidate is not None and best_score >= config.app.llm_judge_score_threshold:
-                            cache_hit = best_candidate
-                            cache_hit["hit_type_override"] = "llm_judge_hit"
-                            logger.info(
-                                f"[cache:llm_judge_selected] tenant={tenant_id} db={db_id} "
-                                f"score={best_score} "
-                                f"similarity={cache_hit['similarity']:.4f} "
-                                f"threshold={config.app.llm_judge_score_threshold}"
-                            )
-                        else:
-                            logger.info(
-                                f"[cache:llm_judge_miss] tenant={tenant_id} db={db_id} "
-                                f"best_score={best_score} "
-                                f"threshold={config.app.llm_judge_score_threshold}"
-                            )
-
             if cache_hit:
-                cached = cache_hit["response_payload"]
-                # Validate cached SQL is still valid before reusing
-                try:
-                    loop = asyncio.get_event_loop()
-                    is_valid, _ = await loop.run_in_executor(
-                        None,
-                        lambda: metabase_client.validate_sql(cached["sql"], db_id, tenant_id)
-                    )
-                except Exception:
-                    is_valid = False
-
-                if not is_valid:
-                    logger.info(
-                        f"[cache:rejected] tenant={tenant_id} db={db_id} "
-                        f"similarity={cache_hit['similarity']:.4f} "
-                        f"reason=sql_validation_failed"
-                    )
-                    cache_hit = None
-                else:
-                    hit_type = cache_hit.get("hit_type_override") or (
-                        "exact_hit" if cache_hit["similarity"] == 1.0 else "semantic_hit"
-                    )
-                    tokens_saved = cached.get("tokens", {}).get("total_tokens", 0)
-                    initial_viz_settings = {}
-                    if "map" in cached.get("visualization_options", []):
-                        initial_viz_settings["map.region"] = os.getenv(
-                            "MB_MAP_REGION_UUID", "1c5d50ee-4389-4593-37c1-fa8d4687ff4c"
-                        )
-                    card_id = metabase_client.create_card(
-                        cached["sql"], db_id, collection_id, cached["title"],
-                        tenant_id=tenant_id,
-                        visualization_settings=initial_viz_settings
-                    )
-                    cache_repository.touch(cache_hit["cache_id"])
-                    if hit_type == "semantic_hit":
-                        logger.info(
-                            f"[cache:semantic_hit] tenant={tenant_id} db={db_id} "
-                            f"similarity={cache_hit['similarity']:.4f} "
-                            f"threshold={config.app.semantic_cache_threshold} "
-                            f"tokens_saved={tokens_saved}"
-                        )
-                    else:
-                        logger.info(
-                            f"[cache:{hit_type}] tenant={tenant_id} db={db_id} "
-                            f"similarity={cache_hit['similarity']:.4f} "
-                            f"tokens_saved={tokens_saved}"
-                        )
-                    return jsonify({
-                        "card_id": card_id,
-                        "x_field": cached.get("x_field", []),
-                        "y_field": cached.get("y_field", []),
-                        "title": cached["title"],
-                        "visualization_options": cached.get("visualization_options", []),
-                        "SQL": cached["sql"],
-                        "tokens": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
-                        "from_cache": True,
-                        "cache_similarity": round(cache_hit["similarity"], 4),
-                        "cache_hit_type": hit_type,
-                        "cache_original_query": cache_hit.get("query_text", "") if hit_type == "llm_judge_hit" else None,
-                    }), 200
-        # ── End cache lookup ─────────────────────────────────────────────────
-        if config.app.semantic_cache_enabled and not is_retry:
+                response = await _serve_cache_hit(cache_hit, db_id, collection_id, tenant_id)
+                if response is not None:
+                    return response
             logger.info(
-                f"[cache:miss] tenant={tenant_id} db={db_id} "
-                f"query=\"{normalized_query[:80]}\""
+                f"[cache:miss] tenant={tenant_id} db={db_id} query=\"{normalized_query[:80]}\""
             )
+        # ── End cache lookup ─────────────────────────────────────────────────
 
-        # Generate SQL from natural language
         logger.info("Starting SQL generation...")
         try:
             sql, metadata, sql_tokens, error_detail = await sql_generator.generate_sql(
@@ -616,58 +652,25 @@ def ask():
 
         if not sql or not metadata:
             logger.warning("SQL generation failed - returning fail response")
-            return _error_response(
-                "ai_failure",
-                "I couldn't generate a report from that question.",
-                422
-            )
+            return _error_response("ai_failure", "I couldn't generate a report from that question.", 422)
 
         logger.debug(f"SQL: {sql}")
         logger.debug(f"Metadata: {metadata}")
-        logger.info("About to create Metabase card...")
-        logger.debug(f"Metabase client type: {type(metabase_client)}")
-
-        # Create Metabase card
         logger.info(f"Creating Metabase card with SQL length: {len(sql)}")
-        logger.debug("Calling metabase_client.create_card...")
-        initial_viz_settings = {}
-        if "map" in metadata.get("visualization_options", []):
-            initial_viz_settings["map.region"] = os.getenv("MB_MAP_REGION_UUID", "1c5d50ee-4389-4593-37c1-fa8d4687ff4c")
 
         card_id = metabase_client.create_card(
             sql, db_id, collection_id, metadata['title'],
             tenant_id=tenant_id,
-            visualization_settings=initial_viz_settings
+            visualization_settings=_build_viz_settings(metadata.get("visualization_options", [])),
         )
         logger.info(f"Card created successfully with ID: {card_id}")
 
         # ── Store result in semantic cache ───────────────────────────────────
         if config.app.semantic_cache_enabled and not error_detail:
-            try:
-                if query_embedding is None:
-                    loop = asyncio.get_event_loop()
-                    query_embedding = await loop.run_in_executor(
-                        None, embedding_manager.embed_query, normalized_query
-                    )
-                cache_repository.save(
-                    tenant_id, db_id, schema_types, collection_name,
-                    question, normalized_query, query_embedding,
-                    {
-                        "sql": sql,
-                        "title": metadata.get("title", "Untitled"),
-                        "x_field": metadata.get("x_axis", []),
-                        "y_field": metadata.get("y_axis", []),
-                        "visualization_options": metadata.get("visualization_options", []),
-                        "tokens": sql_tokens,
-                    }
-                )
-                cache_repository.ensure_hnsw_index()
-                logger.info(
-                    f"Cache stored: tenant={tenant_id} "
-                    f"tokens={sql_tokens.get('total_tokens', 0)}"
-                )
-            except Exception as cache_err:
-                logger.warning(f"Cache store failed (non-fatal): {cache_err}")
+            await _store_query_cache(
+                tenant_id, db_id, schema_types, collection_name,
+                question, normalized_query, query_embedding, sql, metadata, sql_tokens
+            )
         # ── End cache store ──────────────────────────────────────────────────
 
         return {
@@ -677,9 +680,9 @@ def ask():
             "title": metadata.get("title", "Untitled"),
             "visualization_options": metadata.get('visualization_options', []),
             "SQL": sql,
-            "tokens": sql_tokens  # Include token usage from SQL generation
+            "tokens": sql_tokens,
         }, 200
-    
+
     try:
         return asyncio.run(async_ask())
     except Exception as e:

--- a/applications/Unity.AI.Reporting.Backend/src/api.py
+++ b/applications/Unity.AI.Reporting.Backend/src/api.py
@@ -7,11 +7,12 @@ import asyncio
 import logging
 import datetime
 from config import config
-from database import db_manager, chat_repository, feedback_repository
+from database import db_manager, chat_repository, feedback_repository, cache_repository
 from metabase import metabase_client
 from chat import chat_manager
 from sql_generator import sql_generator
 from auth import require_auth, get_user_from_token
+from embeddings import embedding_manager
 from static_routes import add_static_routes
 import os
 import re
@@ -397,23 +398,95 @@ def ask():
         is_retry = bool(data.get("is_retry", False))
         retry_error_type = data.get("retry_error_type") or None
         retry_error_detail = data.get("retry_error_detail") or None
-        
+
         # Extract user context from JWT token
         tenant_id = user_data["tenant"]
-        
+
         if not question:
             return abort(400, "question is required")
-        
+
         # Get tenant configuration
         tenant_config = config.get_tenant_config(tenant_id)
         db_id = tenant_config["db_id"]
         collection_id = tenant_config["collection_id"]
+        schema_types = tenant_config.get("schema_types", ["public"])
+        collection_name = config.app.collection_name
 
         logger.info(f"Request - Tenant: {tenant_id}, DB: {db_id}, Collection: {collection_id}")
 
         # Extract past questions from conversation
         past_questions = chat_manager.extract_past_questions(conversation)
         logger.debug(f"Extracted {len(past_questions)} past questions")
+
+        # ── Semantic cache lookup ────────────────────────────────────────────
+        cache_hit = None
+        query_embedding = None
+        normalized_query = question.strip().lower()
+
+        if config.app.semantic_cache_enabled and not is_retry:
+            # Layer 1: exact match (no embedding cost)
+            cache_hit = cache_repository.find_exact(
+                tenant_id, db_id, schema_types, collection_name, normalized_query
+            )
+
+            # Layer 2: semantic similarity
+            if not cache_hit:
+                loop = asyncio.get_event_loop()
+                query_embedding = await loop.run_in_executor(
+                    None, embedding_manager.embed_query, normalized_query
+                )
+                cache_hit = cache_repository.find_similar(
+                    tenant_id, db_id, schema_types, collection_name,
+                    query_embedding, config.app.semantic_cache_threshold
+                )
+
+            if cache_hit:
+                cached = cache_hit["response_payload"]
+                # Validate cached SQL is still valid before reusing
+                try:
+                    loop = asyncio.get_event_loop()
+                    is_valid, _ = await loop.run_in_executor(
+                        None,
+                        lambda: metabase_client.validate_sql(cached["sql"], db_id, tenant_id)
+                    )
+                except Exception:
+                    is_valid = False
+
+                if not is_valid:
+                    logger.info(
+                        f"Cache hit rejected — SQL no longer valid "
+                        f"(similarity={cache_hit['similarity']:.3f}, tenant={tenant_id})"
+                    )
+                    cache_hit = None
+                else:
+                    initial_viz_settings = {}
+                    if "map" in cached.get("visualization_options", []):
+                        initial_viz_settings["map.region"] = os.getenv(
+                            "MB_MAP_REGION_UUID", "1c5d50ee-4389-4593-37c1-fa8d4687ff4c"
+                        )
+                    card_id = metabase_client.create_card(
+                        cached["sql"], db_id, collection_id, cached["title"],
+                        tenant_id=tenant_id,
+                        visualization_settings=initial_viz_settings
+                    )
+                    cache_repository.touch(cache_hit["cache_id"])
+                    logger.info(
+                        f"Cache hit served: tenant={tenant_id} "
+                        f"similarity={cache_hit['similarity']:.3f} "
+                        f"tokens_saved≈{cached.get('tokens', {}).get('total_tokens', 0)}"
+                    )
+                    return jsonify({
+                        "card_id": card_id,
+                        "x_field": cached.get("x_field", []),
+                        "y_field": cached.get("y_field", []),
+                        "title": cached["title"],
+                        "visualization_options": cached.get("visualization_options", []),
+                        "SQL": cached["sql"],
+                        "tokens": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+                        "from_cache": True,
+                        "cache_similarity": round(cache_hit["similarity"], 4),
+                    }), 200
+        # ── End cache lookup ─────────────────────────────────────────────────
 
         # Generate SQL from natural language
         logger.info("Starting SQL generation...")
@@ -455,6 +528,35 @@ def ask():
             visualization_settings=initial_viz_settings
         )
         logger.info(f"Card created successfully with ID: {card_id}")
+
+        # ── Store result in semantic cache ───────────────────────────────────
+        if config.app.semantic_cache_enabled and not error_detail:
+            try:
+                if query_embedding is None:
+                    loop = asyncio.get_event_loop()
+                    query_embedding = await loop.run_in_executor(
+                        None, embedding_manager.embed_query, normalized_query
+                    )
+                cache_repository.save(
+                    tenant_id, db_id, schema_types, collection_name,
+                    question, normalized_query, query_embedding,
+                    {
+                        "sql": sql,
+                        "title": metadata.get("title", "Untitled"),
+                        "x_field": metadata.get("x_axis", []),
+                        "y_field": metadata.get("y_axis", []),
+                        "visualization_options": metadata.get("visualization_options", []),
+                        "tokens": sql_tokens,
+                    }
+                )
+                cache_repository.ensure_ivfflat_index()
+                logger.info(
+                    f"Cache stored: tenant={tenant_id} "
+                    f"tokens={sql_tokens.get('total_tokens', 0)}"
+                )
+            except Exception as cache_err:
+                logger.warning(f"Cache store failed (non-fatal): {cache_err}")
+        # ── End cache store ──────────────────────────────────────────────────
 
         return {
             "card_id": card_id,

--- a/applications/Unity.AI.Reporting.Backend/src/api.py
+++ b/applications/Unity.AI.Reporting.Backend/src/api.py
@@ -4,6 +4,7 @@ API module with Flask routes for the application.
 from flask import Flask, request, abort, jsonify
 from flask_cors import CORS
 import asyncio
+import aiohttp
 import logging
 import datetime
 from config import config
@@ -463,10 +464,73 @@ def ask():
                     threshold=config.app.semantic_cache_borderline_low,
                     k=config.app.semantic_cache_top_k
                 )
+                if candidates:
+                    candidate_sims = ', '.join(f"{c['similarity']:.4f}" for c in candidates)
+                    logger.info(
+                        f"[cache:candidates] tenant={tenant_id} db={db_id} "
+                        f"count={len(candidates)} "
+                        f"similarities=[{candidate_sims}]"
+                    )
                 # Direct accept: best candidate clears the high-confidence threshold
-                # Borderline zone [0.85, 0.95) is reserved for Phase 3 LLM judge
                 if candidates and candidates[0]["similarity"] >= config.app.semantic_cache_threshold:
                     cache_hit = candidates[0]
+
+                # Borderline zone [borderline_low, threshold): score ALL candidates in parallel, pick best above threshold
+                if not cache_hit and candidates and config.app.llm_judge_enabled:
+                    borderline = [
+                        c for c in candidates
+                        if c["similarity"] < config.app.semantic_cache_threshold
+                    ]
+                    if borderline:
+                        borderline_sims = ', '.join(f"{c['similarity']:.4f}" for c in borderline)
+                        logger.info(
+                            f"[cache:borderline] tenant={tenant_id} db={db_id} "
+                            f"count={len(borderline)} "
+                            f"similarities=[{borderline_sims}]"
+                        )
+                        async with aiohttp.ClientSession() as judge_session:
+                            results = await asyncio.gather(*[
+                                cache_reranker.llm_judge.score_candidate(
+                                    normalized_query,
+                                    candidate["query_text"],
+                                    judge_session,
+                                    config.ai,
+                                )
+                                for candidate in borderline
+                            ])
+
+                        best_candidate = None
+                        best_score = -1  # sentinel; valid scores are 0..10
+                        for candidate, (score, judge_tokens) in zip(borderline, results):
+                            logger.info(
+                                f"[cache:llm_judge] tenant={tenant_id} db={db_id} "
+                                f"similarity={candidate['similarity']:.4f} "
+                                f"score={score} "
+                                f"tokens={judge_tokens}"
+                            )
+                            if score > best_score or (
+                                score == best_score
+                                and best_candidate is not None
+                                and candidate["similarity"] > best_candidate["similarity"]
+                            ):
+                                best_score = score
+                                best_candidate = candidate
+
+                        if best_candidate is not None and best_score >= config.app.llm_judge_score_threshold:
+                            cache_hit = best_candidate
+                            cache_hit["hit_type_override"] = "llm_judge_hit"
+                            logger.info(
+                                f"[cache:llm_judge_selected] tenant={tenant_id} db={db_id} "
+                                f"score={best_score} "
+                                f"similarity={cache_hit['similarity']:.4f} "
+                                f"threshold={config.app.llm_judge_score_threshold}"
+                            )
+                        else:
+                            logger.info(
+                                f"[cache:llm_judge_miss] tenant={tenant_id} db={db_id} "
+                                f"best_score={best_score} "
+                                f"threshold={config.app.llm_judge_score_threshold}"
+                            )
 
             if cache_hit:
                 cached = cache_hit["response_payload"]
@@ -527,6 +591,7 @@ def ask():
                         "from_cache": True,
                         "cache_similarity": round(cache_hit["similarity"], 4),
                         "cache_hit_type": hit_type,
+                        "cache_original_query": cache_hit.get("query_text", "") if hit_type == "llm_judge_hit" else None,
                     }), 200
         # ── End cache lookup ─────────────────────────────────────────────────
         if config.app.semantic_cache_enabled and not is_retry:

--- a/applications/Unity.AI.Reporting.Backend/src/api.py
+++ b/applications/Unity.AI.Reporting.Backend/src/api.py
@@ -391,7 +391,7 @@ def _build_viz_settings(visualization_options: list) -> dict:
     return {}
 
 
-async def _fuzzy_cache_lookup(tenant_id, db_id, schema_types, collection_name, normalized_query):
+def _fuzzy_cache_lookup(tenant_id, db_id, schema_types, collection_name, normalized_query):
     """Layer 1.5: rapidfuzz match against recent normalized queries."""
     recent = cache_repository.get_recent_normalized_queries(
         tenant_id, db_id, schema_types, collection_name, config.app.fuzzy_match_limit
@@ -498,7 +498,7 @@ async def _semantic_cache_lookup(tenant_id, db_id, schema_types, collection_name
         return cache_hit, None
 
     if config.app.fuzzy_match_enabled:
-        cache_hit = await _fuzzy_cache_lookup(tenant_id, db_id, schema_types, collection_name, normalized_query)
+        cache_hit = _fuzzy_cache_lookup(tenant_id, db_id, schema_types, collection_name, normalized_query)
         if cache_hit:
             return cache_hit, None
 
@@ -588,6 +588,102 @@ async def _store_query_cache(tenant_id, db_id, schema_types, collection_name,
         logger.warning(f"Cache store failed (non-fatal): {cache_err}")
 
 
+async def _try_serve_from_cache(tenant_id, db_id, schema_types, collection_name,
+                                collection_id, normalized_query):
+    """Run all cache layers; return (response_or_None, query_embedding_or_None)."""
+    cache_hit, query_embedding = await _semantic_cache_lookup(
+        tenant_id, db_id, schema_types, collection_name, normalized_query
+    )
+    if not cache_hit:
+        return None, query_embedding
+    return await _serve_cache_hit(cache_hit, db_id, collection_id, tenant_id), query_embedding
+
+
+async def _async_ask(data, user_data):
+    """Core logic for /api/ask, extracted to module level to avoid nesting penalties."""
+    question = data.get("question")
+    conversation = data.get("conversation", [])
+    is_retry = bool(data.get("is_retry", False))
+    retry_error_type = data.get("retry_error_type") or None
+    retry_error_detail = data.get("retry_error_detail") or None
+    tenant_id = user_data["tenant"]
+
+    if not question:
+        return abort(400, "question is required")
+
+    tenant_config = config.get_tenant_config(tenant_id)
+    db_id = tenant_config["db_id"]
+    collection_id = tenant_config["collection_id"]
+    schema_types = tenant_config.get("schema_types", ["public"])
+    collection_name = config.app.collection_name
+
+    logger.info(f"Request - Tenant: {tenant_id}, DB: {db_id}, Collection: {collection_id}")
+
+    past_questions = chat_manager.extract_past_questions(conversation)
+    logger.debug(f"Extracted {len(past_questions)} past questions")
+
+    normalized_query = cache_reranker.normalize_query(question)
+    query_embedding = None
+
+    # ── Semantic cache lookup ────────────────────────────────────────────────
+    if config.app.semantic_cache_enabled and not is_retry:
+        response, query_embedding = await _try_serve_from_cache(
+            tenant_id, db_id, schema_types, collection_name, collection_id, normalized_query
+        )
+        if response is not None:
+            return response
+        logger.info(
+            f"[cache:miss] tenant={tenant_id} db={db_id} query=\"{normalized_query[:80]}\""
+        )
+    # ── End cache lookup ─────────────────────────────────────────────────────
+
+    logger.info("Starting SQL generation...")
+    try:
+        sql, metadata, sql_tokens, error_detail = await sql_generator.generate_sql(
+            question, past_questions, db_id, tenant_id=tenant_id,
+            is_retry=is_retry, retry_error_type=retry_error_type,
+            retry_error_detail=retry_error_detail
+        )
+    except Exception as e:
+        return _classify_sql_generation_error(e)
+
+    logger.info(f"SQL generation completed. SQL exists: {bool(sql)}, Metadata exists: {bool(metadata)}")
+    logger.debug(f"SQL generation tokens: {sql_tokens}")
+
+    if not sql or not metadata:
+        logger.warning("SQL generation failed - returning fail response")
+        return _error_response("ai_failure", "I couldn't generate a report from that question.", 422)
+
+    logger.debug(f"SQL: {sql}")
+    logger.debug(f"Metadata: {metadata}")
+    logger.info(f"Creating Metabase card with SQL length: {len(sql)}")
+
+    card_id = metabase_client.create_card(
+        sql, db_id, collection_id, metadata['title'],
+        tenant_id=tenant_id,
+        visualization_settings=_build_viz_settings(metadata.get("visualization_options", [])),
+    )
+    logger.info(f"Card created successfully with ID: {card_id}")
+
+    # ── Store result in semantic cache ───────────────────────────────────────
+    if config.app.semantic_cache_enabled and not error_detail:
+        await _store_query_cache(
+            tenant_id, db_id, schema_types, collection_name,
+            question, normalized_query, query_embedding, sql, metadata, sql_tokens
+        )
+    # ── End cache store ──────────────────────────────────────────────────────
+
+    return {
+        "card_id": card_id,
+        "x_field": metadata.get('x_axis', []),
+        "y_field": metadata.get('y_axis', []),
+        "title": metadata.get("title", "Untitled"),
+        "visualization_options": metadata.get('visualization_options', []),
+        "SQL": sql,
+        "tokens": sql_tokens,
+    }, 200
+
+
 @app.route("/api/ask", methods=["POST"])
 @require_auth
 def ask():
@@ -597,94 +693,8 @@ def ask():
     """
     data = request.get_json()
     user_data = get_user_from_token()
-
-    async def async_ask():
-        question = data.get("question")
-        conversation = data.get("conversation", [])
-        is_retry = bool(data.get("is_retry", False))
-        retry_error_type = data.get("retry_error_type") or None
-        retry_error_detail = data.get("retry_error_detail") or None
-        tenant_id = user_data["tenant"]
-
-        if not question:
-            return abort(400, "question is required")
-
-        tenant_config = config.get_tenant_config(tenant_id)
-        db_id = tenant_config["db_id"]
-        collection_id = tenant_config["collection_id"]
-        schema_types = tenant_config.get("schema_types", ["public"])
-        collection_name = config.app.collection_name
-
-        logger.info(f"Request - Tenant: {tenant_id}, DB: {db_id}, Collection: {collection_id}")
-
-        past_questions = chat_manager.extract_past_questions(conversation)
-        logger.debug(f"Extracted {len(past_questions)} past questions")
-
-        normalized_query = cache_reranker.normalize_query(question)
-        query_embedding = None
-
-        # ── Semantic cache lookup ────────────────────────────────────────────
-        if config.app.semantic_cache_enabled and not is_retry:
-            cache_hit, query_embedding = await _semantic_cache_lookup(
-                tenant_id, db_id, schema_types, collection_name, normalized_query
-            )
-            if cache_hit:
-                response = await _serve_cache_hit(cache_hit, db_id, collection_id, tenant_id)
-                if response is not None:
-                    return response
-            logger.info(
-                f"[cache:miss] tenant={tenant_id} db={db_id} query=\"{normalized_query[:80]}\""
-            )
-        # ── End cache lookup ─────────────────────────────────────────────────
-
-        logger.info("Starting SQL generation...")
-        try:
-            sql, metadata, sql_tokens, error_detail = await sql_generator.generate_sql(
-                question, past_questions, db_id, tenant_id=tenant_id,
-                is_retry=is_retry, retry_error_type=retry_error_type,
-                retry_error_detail=retry_error_detail
-            )
-        except Exception as e:
-            return _classify_sql_generation_error(e)
-
-        logger.info(f"SQL generation completed. SQL exists: {bool(sql)}, Metadata exists: {bool(metadata)}")
-        logger.debug(f"SQL generation tokens: {sql_tokens}")
-
-        if not sql or not metadata:
-            logger.warning("SQL generation failed - returning fail response")
-            return _error_response("ai_failure", "I couldn't generate a report from that question.", 422)
-
-        logger.debug(f"SQL: {sql}")
-        logger.debug(f"Metadata: {metadata}")
-        logger.info(f"Creating Metabase card with SQL length: {len(sql)}")
-
-        card_id = metabase_client.create_card(
-            sql, db_id, collection_id, metadata['title'],
-            tenant_id=tenant_id,
-            visualization_settings=_build_viz_settings(metadata.get("visualization_options", [])),
-        )
-        logger.info(f"Card created successfully with ID: {card_id}")
-
-        # ── Store result in semantic cache ───────────────────────────────────
-        if config.app.semantic_cache_enabled and not error_detail:
-            await _store_query_cache(
-                tenant_id, db_id, schema_types, collection_name,
-                question, normalized_query, query_embedding, sql, metadata, sql_tokens
-            )
-        # ── End cache store ──────────────────────────────────────────────────
-
-        return {
-            "card_id": card_id,
-            "x_field": metadata.get('x_axis', []),
-            "y_field": metadata.get('y_axis', []),
-            "title": metadata.get("title", "Untitled"),
-            "visualization_options": metadata.get('visualization_options', []),
-            "SQL": sql,
-            "tokens": sql_tokens,
-        }, 200
-
     try:
-        return asyncio.run(async_ask())
+        return asyncio.run(_async_ask(data, user_data))
     except Exception as e:
         logger.error(f"Error in /api/ask: {e}", exc_info=True)
         return _error_response(

--- a/applications/Unity.AI.Reporting.Backend/src/api.py
+++ b/applications/Unity.AI.Reporting.Backend/src/api.py
@@ -14,6 +14,7 @@ from sql_generator import sql_generator
 from auth import require_auth, get_user_from_token
 from embeddings import embedding_manager
 from static_routes import add_static_routes
+import cache_reranker
 import os
 import re
 
@@ -429,6 +430,27 @@ def ask():
                 tenant_id, db_id, schema_types, collection_name, normalized_query
             )
 
+            # Layer 1.5: fuzzy match 
+            if not cache_hit and config.app.fuzzy_match_enabled:
+                recent = cache_repository.get_recent_normalized_queries(
+                    tenant_id, db_id, schema_types, collection_name,
+                    config.app.fuzzy_match_limit
+                )
+                fuzzy_match = cache_reranker.fuzzy_matcher.find_best(
+                    normalized_query, recent, config.app.fuzzy_match_threshold
+                )
+                if fuzzy_match:
+                    cache_hit = cache_repository.find_exact(
+                        tenant_id, db_id, schema_types, collection_name,
+                        fuzzy_match["normalized_query"]
+                    )
+                    if cache_hit:
+                        cache_hit["hit_type_override"] = "fuzzy_hit"
+                        logger.info(
+                            f"[cache:fuzzy_hit] tenant={tenant_id} db={db_id} "
+                            f"score={fuzzy_match['score']:.1f}"
+                        )
+
             # Layer 2: semantic similarity
             if not cache_hit:
                 loop = asyncio.get_event_loop()
@@ -460,7 +482,9 @@ def ask():
                     )
                     cache_hit = None
                 else:
-                    hit_type = "exact_hit" if cache_hit["similarity"] == 1.0 else "semantic_hit"
+                    hit_type = cache_hit.get("hit_type_override") or (
+                        "exact_hit" if cache_hit["similarity"] == 1.0 else "semantic_hit"
+                    )
                     if hit_type == "semantic_hit":
                         logger.info(
                             f"[cache:semantic_hit] tenant={tenant_id} db={db_id} "

--- a/applications/Unity.AI.Reporting.Backend/src/api.py
+++ b/applications/Unity.AI.Reporting.Backend/src/api.py
@@ -454,11 +454,19 @@ def ask():
 
                 if not is_valid:
                     logger.info(
-                        f"Cache hit rejected — SQL no longer valid "
-                        f"(similarity={cache_hit['similarity']:.3f}, tenant={tenant_id})"
+                        f"[cache:rejected] tenant={tenant_id} db={db_id} "
+                        f"similarity={cache_hit['similarity']:.4f} "
+                        f"reason=sql_validation_failed"
                     )
                     cache_hit = None
                 else:
+                    hit_type = "exact_hit" if cache_hit["similarity"] == 1.0 else "semantic_hit"
+                    if hit_type == "semantic_hit":
+                        logger.info(
+                            f"[cache:semantic_hit] tenant={tenant_id} db={db_id} "
+                            f"similarity={cache_hit['similarity']:.4f}"
+                        )
+                    tokens_saved = cached.get("tokens", {}).get("total_tokens", 0)
                     initial_viz_settings = {}
                     if "map" in cached.get("visualization_options", []):
                         initial_viz_settings["map.region"] = os.getenv(
@@ -471,9 +479,9 @@ def ask():
                     )
                     cache_repository.touch(cache_hit["cache_id"])
                     logger.info(
-                        f"Cache hit served: tenant={tenant_id} "
-                        f"similarity={cache_hit['similarity']:.3f} "
-                        f"tokens_saved≈{cached.get('tokens', {}).get('total_tokens', 0)}"
+                        f"[cache:{hit_type}] tenant={tenant_id} db={db_id} "
+                        f"similarity={cache_hit['similarity']:.4f} "
+                        f"tokens_saved={tokens_saved}"
                     )
                     return jsonify({
                         "card_id": card_id,
@@ -485,8 +493,14 @@ def ask():
                         "tokens": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
                         "from_cache": True,
                         "cache_similarity": round(cache_hit["similarity"], 4),
+                        "cache_hit_type": hit_type,
                     }), 200
         # ── End cache lookup ─────────────────────────────────────────────────
+        if config.app.semantic_cache_enabled and not is_retry:
+            logger.info(
+                f"[cache:miss] tenant={tenant_id} db={db_id} "
+                f"query=\"{normalized_query[:80]}\""
+            )
 
         # Generate SQL from natural language
         logger.info("Starting SQL generation...")

--- a/applications/Unity.AI.Reporting.Backend/src/app.py
+++ b/applications/Unity.AI.Reporting.Backend/src/app.py
@@ -7,7 +7,7 @@ import logging
 import os
 from typing import Optional
 from config import config
-from database import db_manager
+from database import db_manager, cache_repository
 from embeddings import embedding_manager
 from api import app
 
@@ -68,6 +68,14 @@ def embed_all_tenants():
             logger.error(f"Failed to embed db_id={db_id}: {e}", exc_info=True)
 
     logger.info("Finished embedding all tenant databases.")
+
+    # Evict stale cache entries (older than 30 days) after re-embedding
+    try:
+        deleted = cache_repository.evict_old(days=30)
+        if deleted:
+            logger.info(f"Evicted {deleted} stale semantic cache entries")
+    except Exception as e:
+        logger.warning(f"Cache eviction failed (non-fatal): {e}")
 
 
 def run_server():

--- a/applications/Unity.AI.Reporting.Backend/src/cache_reranker.py
+++ b/applications/Unity.AI.Reporting.Backend/src/cache_reranker.py
@@ -1,9 +1,12 @@
 """
 cache_reranker.py — Multi-layer cache reranking.
-Phase 1: FuzzyMatcher, normalize_query.
+Phase 1: FuzzyMatcher — rapidfuzz layer 1.5 between exact and embedding search.
+Phase 2: normalize_query — whitespace, punctuation, domain abbreviation expansion.
+Phase 3: LLMJudge — binary equivalence judge for borderline cosine zone.
 """
 import logging
 import re
+import aiohttp
 from typing import Optional, List, Dict
 
 from rapidfuzz import fuzz, process
@@ -107,3 +110,108 @@ class FuzzyMatcher:
 
 
 fuzzy_matcher = FuzzyMatcher()
+
+
+_SCORER_SYSTEM = "You are a query equivalence scorer. Reply with a single integer from 0 to 10 and nothing else."
+
+_SCORER_PROMPT = """\
+Rate the semantic equivalence of these two analytical questions on a scale of 0 to 10.
+
+Q1: {q1}
+Q2: {q2}
+
+Scoring guide:
+  10 — Identical intent; the same SQL would correctly answer both.
+   8-9 — Same intent, trivially different phrasing only (synonyms, word order).
+   5-7 — Overlapping topic but differ in at least one of: filters, time range,
+          grouping dimension, or aggregation function.
+   2-4 — Related subject area but clearly different questions.
+   0-1 — Unrelated or contradictory.
+
+Penalise for ANY difference in:
+- Filters (WHERE clauses, included/excluded categories)
+- Aggregation (SUM vs COUNT, row-level vs aggregate)
+- Grouping dimension (GROUP BY fields)
+- Time range (this year, last month, fiscal year, YTD)
+- Named entities (specific programs, regions, columns)
+
+Reply with exactly one integer, no punctuation, no explanation.\
+"""
+
+
+class LLMJudge:
+    """Phase 3 — Scored equivalence ranker for borderline cosine zone [low, threshold).
+
+    Calls the configured Azure OpenAI deployment with a 0-10 scoring prompt.
+    Scores ALL borderline candidates and returns the best one above the threshold,
+    rather than stopping at the first acceptable match.
+    Fail-safe: returns score=0 on any API error — a miss is always safer than
+    a false cache hit that returns wrong SQL.
+    """
+
+    async def score_candidate(
+        self,
+        q1: str,
+        q2: str,
+        session: aiohttp.ClientSession,
+        ai_config,
+    ) -> tuple[int, int]:
+        """Return (score, total_tokens). score in [0, 10]. Returns (0, 0) on any error."""
+        try:
+            headers = {
+                "api-key": ai_config.azure_api_key,
+                "Content-Type": "application/json",
+            }
+            endpoint = (
+                f"{ai_config.azure_endpoint}/openai/deployments/"
+                f"{ai_config.azure_deployment}/chat/completions"
+                f"?api-version={ai_config.azure_api_version}"
+            )
+            payload = {
+                "messages": [
+                    {"role": "system", "content": _SCORER_SYSTEM},
+                    {"role": "user", "content": _SCORER_PROMPT.format(q1=q1, q2=q2)},
+                ],
+                "max_completion_tokens": 1000,
+            }
+            if ai_config.supports_temperature:
+                payload["temperature"] = 0
+            async with session.post(endpoint, headers=headers, json=payload) as resp:
+                if resp.status != 200:
+                    error_body = await resp.text()
+                    logger.warning(f"[llm_judge] API error status={resp.status} body={error_body}")
+                    return 0, 0
+                data = await resp.json()
+                choice = data["choices"][0]
+                finish_reason = choice.get("finish_reason", "unknown")
+                text = choice["message"].get("content") or ""
+                usage = data.get("usage", {})
+                tokens = usage.get("total_tokens", 0)
+                reasoning_tokens = usage.get("completion_tokens_details", {}).get("reasoning_tokens", 0)
+                if finish_reason == "content_filter":
+                    logger.warning(
+                        f"[llm_judge] content_filter triggered — defaulting score=0"
+                    )
+                    return 0, tokens
+                score = self._parse_score(text)
+                logger.debug(
+                    f"[llm_judge] finish_reason={finish_reason} "
+                    f"reasoning_tokens={reasoning_tokens} "
+                    f"raw_response={text!r} parsed_score={score}"
+                )
+                return score, tokens
+        except Exception as exc:
+            logger.warning(f"[llm_judge] Exception, defaulting score=0: {exc}")
+            return 0, 0
+
+    def _parse_score(self, text: str) -> int:
+        """Parse integer 0-10 from LLM output. Returns 0 on any parse failure."""
+        cleaned = re.sub(r'[^0-9.]', ' ', text.strip()).strip()
+        first_token = cleaned.split()[0] if cleaned.split() else ""
+        try:
+            return max(0, min(10, int(float(first_token))))
+        except (ValueError, IndexError):
+            return 0
+
+
+llm_judge = LLMJudge()

--- a/applications/Unity.AI.Reporting.Backend/src/cache_reranker.py
+++ b/applications/Unity.AI.Reporting.Backend/src/cache_reranker.py
@@ -1,13 +1,43 @@
 """
 cache_reranker.py — Multi-layer cache reranking.
-Phase 1: FuzzyMatcher only.
+Phase 1: FuzzyMatcher, normalize_query.
 """
 import logging
+import re
 from typing import Optional, List, Dict
 
 from rapidfuzz import fuzz, process
 
 logger = logging.getLogger(__name__)
+
+# Domain-specific BC Government fiscal reporting abbreviations.
+# Extend this list as new patterns are identified from query logs.
+_ABBREVIATIONS = [
+    (re.compile(r'\bfy\s*(\d{4})\b', re.I),  r'fiscal year \1'),  # FY2024 → fiscal year 2024
+    (re.compile(r'\bq([1-4])\b', re.I),        r'quarter \1'),      # Q3 → quarter 3
+    (re.compile(r'\bytd\b', re.I),             'year to date'),
+    (re.compile(r'\bmtd\b', re.I),             'month to date'),
+    (re.compile(r'\bqtd\b', re.I),             'quarter to date'),
+    (re.compile(r'\bapprox\.?\b', re.I),       'approximately'),
+]
+
+
+def normalize_query(text: str) -> str:
+    """Normalise a natural-language query before any cache lookup.
+
+    Safe operations only: whitespace collapsing, trailing punctuation removal,
+    and domain-specific abbreviation expansion.
+
+    Stopword removal and stemming are intentionally excluded — they hurt
+    transformer embedding quality for short analytical NL queries where
+    every word carries semantic weight (e.g. 'not', 'by', 'excluding').
+    """
+    text = text.strip().lower()
+    text = re.sub(r'\s+', ' ', text)            # collapse multiple spaces
+    text = re.sub(r'[?!.]+$', '', text).strip() # strip trailing punctuation
+    for pattern, replacement in _ABBREVIATIONS:
+        text = pattern.sub(replacement, text)
+    return text
 
 
 class FuzzyMatcher:

--- a/applications/Unity.AI.Reporting.Backend/src/cache_reranker.py
+++ b/applications/Unity.AI.Reporting.Backend/src/cache_reranker.py
@@ -112,28 +112,36 @@ class FuzzyMatcher:
 fuzzy_matcher = FuzzyMatcher()
 
 
-_SCORER_SYSTEM = "You are a query equivalence scorer. Reply with a single integer from 0 to 10 and nothing else."
+_SCORER_SYSTEM = (
+    "You are a strict query equivalence scorer for an analytical SQL cache system. "
+    "Your job is to detect any difference that would cause a different SQL query to be required. "
+    "When in doubt, score lower — a false cache hit returns wrong data. "
+    "Reply with a single integer from 0 to 10 and nothing else."
+)
 
 _SCORER_PROMPT = """\
 Rate the semantic equivalence of these two analytical questions on a scale of 0 to 10.
+Two questions are equivalent only if the SAME SQL query would correctly answer both.
 
 Q1: {q1}
 Q2: {q2}
 
 Scoring guide:
-  10 — Identical intent; the same SQL would correctly answer both.
-   8-9 — Same intent, trivially different phrasing only (synonyms, word order).
-   5-7 — Overlapping topic but differ in at least one of: filters, time range,
-          grouping dimension, or aggregation function.
-   2-4 — Related subject area but clearly different questions.
+  10 — Identical intent; the same SQL correctly answers both.
+   8-9 — Same intent; only trivial phrasing differences (synonyms, word order, punctuation).
+          No difference in time range, filters, aggregation, grouping, or entities.
+   5-7 — Same topic; differ in grouping dimension only (e.g. by region vs by sector),
+          while time range, filters, and aggregation are identical.
+   2-4 — Differ in time range, filter value, aggregation function, metric, or named entity —
+          these require different SQL and produce different results.
    0-1 — Unrelated or contradictory.
 
-Penalise for ANY difference in:
-- Filters (WHERE clauses, included/excluded categories)
-- Aggregation (SUM vs COUNT, row-level vs aggregate)
-- Grouping dimension (GROUP BY fields)
-- Time range (this year, last month, fiscal year, YTD)
-- Named entities (specific programs, regions, columns)
+Hard ceiling rules — score MUST NOT exceed:
+- Time range differs (e.g. "last year" vs "this year", Q1 vs Q2, 2023 vs 2024, YTD vs full year): 4
+- Filter value differs (e.g. region A vs B, approved vs pending, one program vs another): 4
+- Aggregation function differs (e.g. COUNT vs SUM, average vs total): 4
+- Measured column differs (e.g. approved amount vs requested amount): 4
+- Grouping dimension differs (e.g. by region vs by sector): 5
 
 Reply with exactly one integer, no punctuation, no explanation.\
 """

--- a/applications/Unity.AI.Reporting.Backend/src/cache_reranker.py
+++ b/applications/Unity.AI.Reporting.Backend/src/cache_reranker.py
@@ -1,0 +1,79 @@
+"""
+cache_reranker.py — Multi-layer cache reranking.
+Phase 1: FuzzyMatcher only.
+"""
+import logging
+from typing import Optional, List, Dict
+
+from rapidfuzz import fuzz, process
+
+logger = logging.getLogger(__name__)
+
+
+class FuzzyMatcher:
+    """Layer 1.5: rapidfuzz token_sort_ratio + ratio with length guard.
+
+    Uses two algorithms and takes the higher score:
+    - token_sort_ratio: handles word-order variations ("show grants this year" vs
+      "this year show grants")
+    - ratio: character-level Levenshtein distance, best for typos
+
+    A length ratio guard (±30%) rejects pairs that share words but differ
+    in intent due to significant length differences.
+    """
+
+    def find_best(
+        self,
+        query: str,
+        candidates: List[Dict],
+        threshold: float = 92.0,
+    ) -> Optional[Dict]:
+        """Return the best-matching candidate above threshold or None.
+
+        Args:
+            query: The normalized incoming query.
+            candidates: List of {"normalized_query": str, "cache_id": str}.
+            threshold: Minimum score on 0–100 scale to accept a match.
+
+        Returns:
+            The matching candidate dict with an added "score" key, or None.
+        """
+        if not candidates:
+            return None
+
+        candidate_strings = [c["normalized_query"] for c in candidates]
+
+        # token_sort_ratio is order-independent — best for rephrased queries
+        result = process.extractOne(
+            query, candidate_strings, scorer=fuzz.token_sort_ratio
+        )
+        if result is None:
+            return None
+
+        matched_str, token_score, idx = result
+
+        # Also score with character-level ratio for typo detection
+        char_score = fuzz.ratio(query, matched_str)
+        final_score = max(token_score, char_score)
+
+        if final_score < threshold:
+            return None
+
+        if not self._length_ok(query, matched_str):
+            return None
+
+        return {**candidates[idx], "score": final_score}
+
+    def _length_ok(self, q1: str, q2: str, max_ratio: float = 0.30) -> bool:
+        """Return True if the two strings are within max_ratio length of each other.
+
+        Prevents accepting fuzzy matches where one query has significantly more
+        content than the other (different intent despite word overlap).
+        """
+        longer = max(len(q1), len(q2))
+        if longer == 0:
+            return False
+        return abs(len(q1) - len(q2)) / longer <= max_ratio
+
+
+fuzzy_matcher = FuzzyMatcher()

--- a/applications/Unity.AI.Reporting.Backend/src/cache_reranker.py
+++ b/applications/Unity.AI.Reporting.Backend/src/cache_reranker.py
@@ -36,8 +36,8 @@ def normalize_query(text: str) -> str:
     every word carries semantic weight (e.g. 'not', 'by', 'excluding').
     """
     text = text.strip().lower()
-    text = re.sub(r'\s+', ' ', text)            # collapse multiple spaces
-    text = re.sub(r'[?!.]+$', '', text).strip() # strip trailing punctuation
+    text = re.sub(r'\s+', ' ', text)              # collapse multiple spaces
+    text = re.sub(r'[?!.]{1,10}$', '', text).strip() # strip trailing punctuation
     for pattern, replacement in _ABBREVIATIONS:
         text = pattern.sub(replacement, text)
     return text
@@ -198,7 +198,7 @@ class LLMJudge:
                 reasoning_tokens = usage.get("completion_tokens_details", {}).get("reasoning_tokens", 0)
                 if finish_reason == "content_filter":
                     logger.warning(
-                        f"[llm_judge] content_filter triggered — defaulting score=0"
+                        "[llm_judge] content_filter triggered — defaulting score=0"
                     )
                     return 0, tokens
                 score = self._parse_score(text)

--- a/applications/Unity.AI.Reporting.Backend/src/config.py
+++ b/applications/Unity.AI.Reporting.Backend/src/config.py
@@ -86,7 +86,10 @@ class AppConfig:
     collection_name: str = "embedded_schema"
     semantic_cache_enabled: bool = True
     semantic_cache_threshold: float = 0.95
-    
+    fuzzy_match_enabled: bool = True
+    fuzzy_match_threshold: float = 92.0
+    fuzzy_match_limit: int = 200
+
 
 class Config:
     """Central configuration manager"""
@@ -129,7 +132,10 @@ class Config:
             testing=False,
             embed_worksheets=os.getenv("EMBED_WORKSHEETS", "true").lower() == "true",
             semantic_cache_enabled=os.getenv("SEMANTIC_CACHE_ENABLED", "true").lower() == "true",
-            semantic_cache_threshold=float(os.getenv("SEMANTIC_CACHE_THRESHOLD", "0.95"))
+            semantic_cache_threshold=float(os.getenv("SEMANTIC_CACHE_THRESHOLD", "0.95")),
+            fuzzy_match_enabled=os.getenv("FUZZY_MATCH_ENABLED", "true").lower() == "true",
+            fuzzy_match_threshold=float(os.getenv("FUZZY_MATCH_THRESHOLD", "92")),
+            fuzzy_match_limit=int(os.getenv("FUZZY_MATCH_LIMIT", "200")),
         )
         
         # Tenant configuration - extensible for different use cases

--- a/applications/Unity.AI.Reporting.Backend/src/config.py
+++ b/applications/Unity.AI.Reporting.Backend/src/config.py
@@ -91,6 +91,8 @@ class AppConfig:
     fuzzy_match_limit: int = 200
     semantic_cache_borderline_low: float = 0.85
     semantic_cache_top_k: int = 5
+    llm_judge_enabled: bool = False
+    llm_judge_score_threshold: float = 7.0
 
 
 class Config:
@@ -140,6 +142,8 @@ class Config:
             fuzzy_match_limit=int(os.getenv("FUZZY_MATCH_LIMIT", "200")),
             semantic_cache_borderline_low=float(os.getenv("SEMANTIC_CACHE_BORDERLINE_LOW", "0.85")),
             semantic_cache_top_k=int(os.getenv("SEMANTIC_CACHE_TOP_K", "5")),
+            llm_judge_enabled=os.getenv("LLM_JUDGE_ENABLED", "false").lower() == "true",
+            llm_judge_score_threshold=float(os.getenv("LLM_JUDGE_SCORE_THRESHOLD", "7.0")),
         )
         
         # Tenant configuration - extensible for different use cases

--- a/applications/Unity.AI.Reporting.Backend/src/config.py
+++ b/applications/Unity.AI.Reporting.Backend/src/config.py
@@ -89,6 +89,8 @@ class AppConfig:
     fuzzy_match_enabled: bool = True
     fuzzy_match_threshold: float = 92.0
     fuzzy_match_limit: int = 200
+    semantic_cache_borderline_low: float = 0.85
+    semantic_cache_top_k: int = 5
 
 
 class Config:
@@ -136,6 +138,8 @@ class Config:
             fuzzy_match_enabled=os.getenv("FUZZY_MATCH_ENABLED", "true").lower() == "true",
             fuzzy_match_threshold=float(os.getenv("FUZZY_MATCH_THRESHOLD", "92")),
             fuzzy_match_limit=int(os.getenv("FUZZY_MATCH_LIMIT", "200")),
+            semantic_cache_borderline_low=float(os.getenv("SEMANTIC_CACHE_BORDERLINE_LOW", "0.85")),
+            semantic_cache_top_k=int(os.getenv("SEMANTIC_CACHE_TOP_K", "5")),
         )
         
         # Tenant configuration - extensible for different use cases

--- a/applications/Unity.AI.Reporting.Backend/src/config.py
+++ b/applications/Unity.AI.Reporting.Backend/src/config.py
@@ -92,7 +92,7 @@ class AppConfig:
     semantic_cache_borderline_low: float = 0.85
     semantic_cache_top_k: int = 5
     llm_judge_enabled: bool = False
-    llm_judge_score_threshold: float = 7.0
+    llm_judge_score_threshold: float = 8.0
 
 
 class Config:
@@ -143,7 +143,7 @@ class Config:
             semantic_cache_borderline_low=float(os.getenv("SEMANTIC_CACHE_BORDERLINE_LOW", "0.85")),
             semantic_cache_top_k=int(os.getenv("SEMANTIC_CACHE_TOP_K", "5")),
             llm_judge_enabled=os.getenv("LLM_JUDGE_ENABLED", "false").lower() == "true",
-            llm_judge_score_threshold=float(os.getenv("LLM_JUDGE_SCORE_THRESHOLD", "7.0")),
+            llm_judge_score_threshold=float(os.getenv("LLM_JUDGE_SCORE_THRESHOLD", "8.0")),
         )
         
         # Tenant configuration - extensible for different use cases

--- a/applications/Unity.AI.Reporting.Backend/src/config.py
+++ b/applications/Unity.AI.Reporting.Backend/src/config.py
@@ -84,6 +84,8 @@ class AppConfig:
     testing: bool
     embed_worksheets: bool = False
     collection_name: str = "embedded_schema"
+    semantic_cache_enabled: bool = True
+    semantic_cache_threshold: float = 0.95
     
 
 class Config:
@@ -125,7 +127,9 @@ class Config:
             flask_env=flask_env,
             debug=flask_env != "production",
             testing=False,
-            embed_worksheets=os.getenv("EMBED_WORKSHEETS", "true").lower() == "true"
+            embed_worksheets=os.getenv("EMBED_WORKSHEETS", "true").lower() == "true",
+            semantic_cache_enabled=os.getenv("SEMANTIC_CACHE_ENABLED", "true").lower() == "true",
+            semantic_cache_threshold=float(os.getenv("SEMANTIC_CACHE_THRESHOLD", "0.95"))
         )
         
         # Tenant configuration - extensible for different use cases

--- a/applications/Unity.AI.Reporting.Backend/src/database.py
+++ b/applications/Unity.AI.Reporting.Backend/src/database.py
@@ -480,6 +480,41 @@ class CacheRepository:
                     }
         return None
 
+    def find_similar_topk(
+        self, tenant_id: str, db_id: int, schema_types: list,
+        collection_name: str, embedding: list,
+        threshold: float, k: int = 5
+    ) -> list:
+        """Top-K cosine similarity search with floor = threshold.
+        Returns list sorted by similarity DESC (closest first).
+        Each dict: cache_id, response_payload, query_text, similarity."""
+        fp = self.build_fingerprint(db_id, schema_types, collection_name)
+        embedding_str = "[" + ",".join(str(v) for v in embedding) + "]"
+        with self.db.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SET hnsw.ef_search = 64")
+                cur.execute("""
+                    SELECT cache_id, response_payload, query_text,
+                           1 - (query_embedding <=> %s::vector) AS similarity
+                    FROM query_cache
+                    WHERE tenant_id = %s
+                      AND db_id = %s
+                      AND schema_fingerprint = %s
+                      AND 1 - (query_embedding <=> %s::vector) >= %s
+                    ORDER BY query_embedding <=> %s::vector
+                    LIMIT %s
+                """, (embedding_str, tenant_id, db_id, fp,
+                      embedding_str, threshold, embedding_str, k))
+                return [
+                    {
+                        "cache_id": str(row[0]),
+                        "response_payload": row[1],
+                        "query_text": row[2],
+                        "similarity": float(row[3]),
+                    }
+                    for row in cur.fetchall()
+                ]
+
     def get_recent_normalized_queries(
         self, tenant_id: str, db_id: int, schema_types: list,
         collection_name: str, limit: int = 200

--- a/applications/Unity.AI.Reporting.Backend/src/database.py
+++ b/applications/Unity.AI.Reporting.Backend/src/database.py
@@ -458,7 +458,7 @@ class CacheRepository:
         embedding_str = "[" + ",".join(str(v) for v in embedding) + "]"
         with self.db.get_connection() as conn:
             with conn.cursor() as cur:
-                cur.execute("SET ivfflat.probes = 10")
+                cur.execute("SET hnsw.ef_search = 64")
                 cur.execute("""
                     SELECT cache_id, response_payload,
                            1 - (query_embedding <=> %s::vector) AS similarity
@@ -527,8 +527,9 @@ class CacheRepository:
                 conn.commit()
                 return deleted
 
-    def ensure_ivfflat_index(self):
-        """Create the ivfflat index once the table has rows (requires > 0 rows)."""
+    def ensure_hnsw_index(self):
+        """Create the hnsw index once the table has rows. hnsw supports up to 16000 dimensions,
+        unlike ivfflat which caps at 2000 — required for text-embedding-3-large (3072-d)."""
         with self.db.get_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute("SELECT COUNT(*) FROM query_cache")
@@ -537,8 +538,8 @@ class CacheRepository:
                     cur.execute("""
                         CREATE INDEX IF NOT EXISTS idx_query_cache_embedding
                             ON query_cache
-                            USING ivfflat (query_embedding vector_cosine_ops)
-                            WITH (lists = 50)
+                            USING hnsw (query_embedding vector_cosine_ops)
+                            WITH (m = 16, ef_construction = 64)
                     """)
                     conn.commit()
 

--- a/applications/Unity.AI.Reporting.Backend/src/database.py
+++ b/applications/Unity.AI.Reporting.Backend/src/database.py
@@ -77,9 +77,31 @@ class DatabaseManager:
                     CREATE INDEX IF NOT EXISTS idx_feedback_status ON feedback(status);
                 """)
                 
-                # You can add more tables here for extensibility
-                # For example: user_preferences, query_history, etc.
-                
+                # Semantic query cache table
+                cur.execute("""
+                    CREATE TABLE IF NOT EXISTS query_cache (
+                        cache_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                        tenant_id TEXT NOT NULL,
+                        db_id INTEGER NOT NULL,
+                        schema_fingerprint TEXT NOT NULL,
+                        query_text TEXT NOT NULL,
+                        normalized_query TEXT NOT NULL,
+                        query_embedding vector(3072) NOT NULL,
+                        response_payload JSONB NOT NULL,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        accessed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        access_count INTEGER DEFAULT 1
+                    );
+
+                    CREATE UNIQUE INDEX IF NOT EXISTS idx_query_cache_exact
+                        ON query_cache(tenant_id, db_id, schema_fingerprint, normalized_query);
+                    CREATE INDEX IF NOT EXISTS idx_query_cache_tenant_db
+                        ON query_cache(tenant_id, db_id, schema_fingerprint);
+                """)
+
+                # ivfflat index requires rows to exist first — created separately via evict_old
+                # or on first similarity search. Skip here to avoid error on empty table.
+
                 conn.commit()
     
     def purge_embeddings(self, db_id: Optional[int] = None, collection_name: str = "embedded_schema"):
@@ -393,7 +415,136 @@ class FeedbackRepository:
                 return feedback_list
 
 
+class CacheRepository:
+    """Repository for semantic query cache"""
+
+    def __init__(self, db_manager: DatabaseManager):
+        self.db = db_manager
+
+    @staticmethod
+    def build_fingerprint(db_id: int, schema_types: list, collection_name: str) -> str:
+        """Build a schema fingerprint string for cache scoping."""
+        return f"{db_id}:{':'.join(sorted(schema_types))}:{collection_name}"
+
+    def find_exact(self, tenant_id: str, db_id: int, schema_types: list,
+                   collection_name: str, normalized_query: str) -> Optional[Dict[str, Any]]:
+        """Layer 1: exact normalized-query match — no embedding cost."""
+        fp = self.build_fingerprint(db_id, schema_types, collection_name)
+        with self.db.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    SELECT cache_id, response_payload
+                    FROM query_cache
+                    WHERE tenant_id = %s
+                      AND db_id = %s
+                      AND schema_fingerprint = %s
+                      AND normalized_query = %s
+                    LIMIT 1
+                """, (tenant_id, db_id, fp, normalized_query))
+                row = cur.fetchone()
+                if row:
+                    return {
+                        "cache_id": str(row[0]),
+                        "response_payload": row[1],
+                        "similarity": 1.0
+                    }
+        return None
+
+    def find_similar(self, tenant_id: str, db_id: int, schema_types: list,
+                     collection_name: str, embedding: list,
+                     threshold: float) -> Optional[Dict[str, Any]]:
+        """Layer 2: cosine similarity search via pgvector."""
+        fp = self.build_fingerprint(db_id, schema_types, collection_name)
+        embedding_str = "[" + ",".join(str(v) for v in embedding) + "]"
+        with self.db.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SET ivfflat.probes = 10")
+                cur.execute("""
+                    SELECT cache_id, response_payload,
+                           1 - (query_embedding <=> %s::vector) AS similarity
+                    FROM query_cache
+                    WHERE tenant_id = %s
+                      AND db_id = %s
+                      AND schema_fingerprint = %s
+                      AND 1 - (query_embedding <=> %s::vector) >= %s
+                    ORDER BY query_embedding <=> %s::vector
+                    LIMIT 1
+                """, (embedding_str, tenant_id, db_id, fp,
+                      embedding_str, threshold, embedding_str))
+                row = cur.fetchone()
+                if row:
+                    return {
+                        "cache_id": str(row[0]),
+                        "response_payload": row[1],
+                        "similarity": float(row[2])
+                    }
+        return None
+
+    def save(self, tenant_id: str, db_id: int, schema_types: list, collection_name: str,
+             query_text: str, normalized_query: str, embedding: list,
+             response_payload: Dict[str, Any]):
+        """Store a new cache entry, updating if the normalized query already exists."""
+        fp = self.build_fingerprint(db_id, schema_types, collection_name)
+        embedding_str = "[" + ",".join(str(v) for v in embedding) + "]"
+        with self.db.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    INSERT INTO query_cache
+                        (tenant_id, db_id, schema_fingerprint, query_text, normalized_query,
+                         query_embedding, response_payload)
+                    VALUES (%s, %s, %s, %s, %s, %s::vector, %s)
+                    ON CONFLICT (tenant_id, db_id, schema_fingerprint, normalized_query)
+                    DO UPDATE SET
+                        response_payload = EXCLUDED.response_payload,
+                        query_embedding  = EXCLUDED.query_embedding,
+                        accessed_at      = NOW(),
+                        access_count     = query_cache.access_count + 1
+                """, (tenant_id, db_id, fp, query_text, normalized_query,
+                      embedding_str, json.dumps(response_payload)))
+                conn.commit()
+
+    def touch(self, cache_id: str):
+        """Update access timestamp and increment hit counter."""
+        with self.db.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    UPDATE query_cache
+                    SET accessed_at  = NOW(),
+                        access_count = access_count + 1
+                    WHERE cache_id = %s
+                """, (cache_id,))
+                conn.commit()
+
+    def evict_old(self, days: int = 30) -> int:
+        """Delete cache entries older than `days` days. Returns count deleted."""
+        with self.db.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    DELETE FROM query_cache
+                    WHERE created_at < NOW() - INTERVAL '%s days'
+                """, (days,))
+                deleted = cur.rowcount
+                conn.commit()
+                return deleted
+
+    def ensure_ivfflat_index(self):
+        """Create the ivfflat index once the table has rows (requires > 0 rows)."""
+        with self.db.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT COUNT(*) FROM query_cache")
+                count = cur.fetchone()[0]
+                if count > 0:
+                    cur.execute("""
+                        CREATE INDEX IF NOT EXISTS idx_query_cache_embedding
+                            ON query_cache
+                            USING ivfflat (query_embedding vector_cosine_ops)
+                            WITH (lists = 50)
+                    """)
+                    conn.commit()
+
+
 # Global instances
 db_manager = DatabaseManager()
 chat_repository = ChatRepository(db_manager)
 feedback_repository = FeedbackRepository(db_manager)
+cache_repository = CacheRepository(db_manager)

--- a/applications/Unity.AI.Reporting.Backend/src/database.py
+++ b/applications/Unity.AI.Reporting.Backend/src/database.py
@@ -521,7 +521,7 @@ class CacheRepository:
             with conn.cursor() as cur:
                 cur.execute("""
                     DELETE FROM query_cache
-                    WHERE created_at < NOW() - INTERVAL '%s days'
+                    WHERE accessed_at < NOW() - %s * INTERVAL '1 day'
                 """, (days,))
                 deleted = cur.rowcount
                 conn.commit()

--- a/applications/Unity.AI.Reporting.Backend/src/database.py
+++ b/applications/Unity.AI.Reporting.Backend/src/database.py
@@ -480,6 +480,29 @@ class CacheRepository:
                     }
         return None
 
+    def get_recent_normalized_queries(
+        self, tenant_id: str, db_id: int, schema_types: list,
+        collection_name: str, limit: int = 200
+    ) -> list:
+        """Fetch recent normalized queries for fuzzy matching.
+        Returns list of {"normalized_query": str, "cache_id": str} ordered by accessed_at DESC."""
+        fp = self.build_fingerprint(db_id, schema_types, collection_name)
+        with self.db.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    SELECT normalized_query, cache_id
+                    FROM query_cache
+                    WHERE tenant_id = %s
+                      AND db_id = %s
+                      AND schema_fingerprint = %s
+                    ORDER BY accessed_at DESC
+                    LIMIT %s
+                """, (tenant_id, db_id, fp, limit))
+                return [
+                    {"normalized_query": row[0], "cache_id": str(row[1])}
+                    for row in cur.fetchall()
+                ]
+
     def save(self, tenant_id: str, db_id: int, schema_types: list, collection_name: str,
              query_text: str, normalized_query: str, embedding: list,
              response_payload: Dict[str, Any]):

--- a/applications/Unity.AI.Reporting.Backend/src/embeddings.py
+++ b/applications/Unity.AI.Reporting.Backend/src/embeddings.py
@@ -336,6 +336,10 @@ class EmbeddingManager:
 
         return retrieved
     
+    def embed_query(self, query: str) -> list:
+        """Return raw embedding vector for a single query string."""
+        return self.embedding_model.embed_query(query)
+
     def get_formatted_schemas(self, query: str, db_id: int) -> str:
         """Get formatted schema text for prompt, grouped by section with headers."""
         schemas = self.search_similar_schemas(query, db_id)

--- a/applications/Unity.AI.Reporting.Frontend/src/app/app.css
+++ b/applications/Unity.AI.Reporting.Frontend/src/app/app.css
@@ -3,15 +3,42 @@
 .cache-badge {
   display: inline-flex;
   align-items: center;
-  padding: 2px 8px;
-  background: #f0fdf4;
-  border: 1px solid #bbf7d0;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 4px 10px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
   border-radius: 4px;
   font-size: 0.8rem;
-  color: #166534;
+  color: #334155;
   margin-bottom: 8px;
   cursor: default;
   user-select: none;
+}
+
+.cache-badge-hint {
+  color: #64748b;
+}
+
+.cache-fresh-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  margin-left: 4px;
+  font-size: inherit;
+  color: #2563eb;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.cache-fresh-btn:hover:not(:disabled) {
+  color: #1d4ed8;
+}
+
+.cache-fresh-btn:disabled {
+  color: #94a3b8;
+  cursor: not-allowed;
+  text-decoration: none;
 }
 
 /* ---------- basics ---------- */

--- a/applications/Unity.AI.Reporting.Frontend/src/app/app.css
+++ b/applications/Unity.AI.Reporting.Frontend/src/app/app.css
@@ -1,3 +1,19 @@
+/* ---------- semantic cache badge ---------- */
+
+.cache-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  color: #166534;
+  margin-bottom: 8px;
+  cursor: default;
+  user-select: none;
+}
+
 /* ---------- basics ---------- */
 
 .outer-container {

--- a/applications/Unity.AI.Reporting.Frontend/src/app/app.html
+++ b/applications/Unity.AI.Reporting.Frontend/src/app/app.html
@@ -96,16 +96,20 @@
                       @if (turn.sql_explanation_visible) {
                         <app-sql-explanation [explanation]="turn.embed.sql_explanation"></app-sql-explanation>
                       }
-                      @if (turn.embed.cache_hit_type === 'semantic_hit') {
+                      @if (turn.embed.cache_hit_type === 'llm_judge_hit') {
                         <div class="cache-badge">
                           Based on a similar previous question.
-                          <span class="cache-badge-hint">Check if this matches what you meant.</span>
+                          @if (turn.embed.cache_original_query) {
+                            <span class="cache-badge-hint">Previous question: "{{ turn.embed.cache_original_query }}"</span>
+                          } @else {
+                            <span class="cache-badge-hint">Check if this matches what you meant.</span>
+                          }
                           <button
                             class="cache-fresh-btn"
                             [disabled]="isLoading"
                             aria-label="Generate a new answer for this question"
                             (click)="getFreshAnswer(turn)">
-                            Generate a new answer
+                            Get fresh answer
                           </button>
                         </div>
                       }

--- a/applications/Unity.AI.Reporting.Frontend/src/app/app.html
+++ b/applications/Unity.AI.Reporting.Frontend/src/app/app.html
@@ -96,6 +96,11 @@
                       @if (turn.sql_explanation_visible) {
                         <app-sql-explanation [explanation]="turn.embed.sql_explanation"></app-sql-explanation>
                       }
+                      @if (turn.embed.from_cache) {
+                        <div class="cache-badge" [title]="'Reused answer · similarity: ' + (turn.embed.cache_similarity | number:'1.2-2')">
+                          Reused answer
+                        </div>
+                      }
                       <div class="metabase-view-container">
                         <button class="metabase-view-btn" (click)="redirectToMB(turn)" title="View in Metabase">
                           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/applications/Unity.AI.Reporting.Frontend/src/app/app.html
+++ b/applications/Unity.AI.Reporting.Frontend/src/app/app.html
@@ -107,7 +107,7 @@
                           <button
                             class="cache-fresh-btn"
                             [disabled]="isLoading"
-                            aria-label="Generate a new answer for this question"
+                            aria-label="Get fresh answer — generate a new answer for this question"
                             (click)="getFreshAnswer(turn)">
                             Get fresh answer
                           </button>

--- a/applications/Unity.AI.Reporting.Frontend/src/app/app.html
+++ b/applications/Unity.AI.Reporting.Frontend/src/app/app.html
@@ -96,9 +96,17 @@
                       @if (turn.sql_explanation_visible) {
                         <app-sql-explanation [explanation]="turn.embed.sql_explanation"></app-sql-explanation>
                       }
-                      @if (turn.embed.from_cache) {
-                        <div class="cache-badge" [title]="'Reused answer · similarity: ' + (turn.embed.cache_similarity | number:'1.2-2')">
-                          Reused answer
+                      @if (turn.embed.cache_hit_type === 'semantic_hit') {
+                        <div class="cache-badge">
+                          Based on a similar previous question.
+                          <span class="cache-badge-hint">Check if this matches what you meant.</span>
+                          <button
+                            class="cache-fresh-btn"
+                            [disabled]="isLoading"
+                            aria-label="Generate a new answer for this question"
+                            (click)="getFreshAnswer(turn)">
+                            Generate a new answer
+                          </button>
                         </div>
                       }
                       <div class="metabase-view-container">

--- a/applications/Unity.AI.Reporting.Frontend/src/app/app.ts
+++ b/applications/Unity.AI.Reporting.Frontend/src/app/app.ts
@@ -423,6 +423,18 @@ export class App implements OnInit, OnDestroy {
     this.askQuestion(nextRetryCount, errorType, turn.errorDetail);
   }
 
+  getFreshAnswer(turn: Turn): void {
+    if (this.isLoading) return;
+    // Resubmit the question with retry_count=1 so the backend skips the semantic cache (is_retry=true).
+    this.question = turn.question;
+    this.conversation = this.conversation.filter(t => t !== turn);
+    this.askQuestion(1);
+  }
+
+  get isLoading(): boolean {
+    return this.conversation.some(t => t.safeUrl === 'loading');
+  }
+
   toggleSidebar(): void {
     this.sidebarOpen = !this.sidebarOpen;
     

--- a/applications/Unity.AI.Reporting.Frontend/src/app/app.ts
+++ b/applications/Unity.AI.Reporting.Frontend/src/app/app.ts
@@ -1,6 +1,7 @@
 import { Component, ViewChild, ElementRef, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
 import { FormsModule } from '@angular/forms';
+import { DecimalPipe } from '@angular/common';
 import { SafeResourceUrl, DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
 import { Embed } from './embed';
@@ -18,7 +19,7 @@ import { environment } from '../environments/environment';
 
 @Component({
   selector: 'app-root',
-  imports: [FormsModule, SqlExplanationComponent, SidebarComponent, ToastComponent],
+  imports: [FormsModule, DecimalPipe, SqlExplanationComponent, SidebarComponent, ToastComponent],
   templateUrl: './app.html',
   styleUrls: ['./app.css']
 })

--- a/applications/Unity.AI.Reporting.Frontend/src/app/embed.ts
+++ b/applications/Unity.AI.Reporting.Frontend/src/app/embed.ts
@@ -14,4 +14,5 @@ export interface Embed {
     };
     from_cache?: boolean;           // True when response was served from semantic cache
     cache_similarity?: number;      // Cosine similarity score (0–1) of the cache hit
+    cache_hit_type?: 'exact_hit' | 'semantic_hit';  // Exact vs fuzzy semantic match
 }

--- a/applications/Unity.AI.Reporting.Frontend/src/app/embed.ts
+++ b/applications/Unity.AI.Reporting.Frontend/src/app/embed.ts
@@ -14,5 +14,6 @@ export interface Embed {
     };
     from_cache?: boolean;           // True when response was served from semantic cache
     cache_similarity?: number;      // Cosine similarity score (0–1) of the cache hit
-    cache_hit_type?: 'exact_hit' | 'semantic_hit';  // Exact vs fuzzy semantic match
+    cache_hit_type?: 'exact_hit' | 'semantic_hit' | 'fuzzy_hit' | 'llm_judge_hit';
+    cache_original_query?: string;  // The original cached query (set for llm_judge_hit only)
 }

--- a/applications/Unity.AI.Reporting.Frontend/src/app/embed.ts
+++ b/applications/Unity.AI.Reporting.Frontend/src/app/embed.ts
@@ -12,4 +12,6 @@ export interface Embed {
         completion_tokens: number;  // Output tokens (combined from SQL generation + explanation)
         total_tokens: number;       // Sum of prompt + completion tokens
     };
+    from_cache?: boolean;           // True when response was served from semantic cache
+    cache_similarity?: number;      // Cosine similarity score (0–1) of the cache hit
 }


### PR DESCRIPTION
Semantic Caching for AI Reporting

Adds a semantic cache layer to the AI Reporting query pipeline to reduce redundant Azure OpenAI calls for similar natural language questions.

Changes:

- Semantic cache — stores query embeddings and generated SQL in PostgreSQL/pgvector; exact and near-duplicate queries are served from cache without hitting the LLM
- Fuzzy matching — handles typos, word-order swaps, and minor rephrasing via normalized query comparison
- Top-k embedding search — upgrades vector similarity search to return multiple candidates for reranking
- LLM judge — for borderline cache candidates, a lightweight LLM call determines if the cached SQL is semantically equivalent; runs in parallel to minimize latency
- Cache logging — tracks cache hits, misses, and LLM judge outcomes in the database
- Bug fixes — resolves ivfflat 2000-dimension limit issue and cache eviction query bug
- UI — surfaces llm_judge_hit status in the frontend