### PR TITLE
Fix SQL parser missing completions when model drops ### section prefix

### DIFF
--- a/applications/Unity.AI.Reporting.Backend/src/sql_generator.py
+++ b/applications/Unity.AI.Reporting.Backend/src/sql_generator.py
@@ -37,7 +37,7 @@ class SQLGenerator:
         self.metadata_pattern = re.compile(
             r"""(?:\#\#\#\s*)?Metadata:\s*
                 (?:```json\s*)?
-                (\{.*?})
+                (\{[^}]*})
                 (?:\s*```)?
             """,
             re.IGNORECASE | re.DOTALL | re.VERBOSE

--- a/applications/Unity.AI.Reporting.Backend/src/sql_generator.py
+++ b/applications/Unity.AI.Reporting.Backend/src/sql_generator.py
@@ -52,7 +52,7 @@ class SQLGenerator:
         
         # Fallback: look for '### SQL:' or plain 'SQL:' header (model sometimes drops ### at high token counts)
         # Reluctant quantifier is intentional: match shortest content up to next section header or end
-        sql_header = re.search(r"(?:###\s*)?SQL:\s*(.+?)(?:\n(?:###\s*)?(?:Metadata:|Reasoning:)|\Z)", text, re.DOTALL) # NOSONAR
+        sql_header = re.search(r"^(?:###\s*)?SQL:\s*(.+?)(?:\n(?:###\s*)?(?:Metadata:|Reasoning:)|\Z)", text, re.DOTALL | re.MULTILINE) # NOSONAR
         if sql_header:
             return sql_header.group(1).strip()
         

--- a/applications/Unity.AI.Reporting.Backend/src/sql_generator.py
+++ b/applications/Unity.AI.Reporting.Backend/src/sql_generator.py
@@ -35,7 +35,7 @@ class SQLGenerator:
         # Regex patterns for extraction
         self.sql_pattern = re.compile(r"```sql\s*(.+?)```", re.I | re.S)
         self.metadata_pattern = re.compile(
-            r"""\#\#\#\s*Metadata:\s*
+            r"""(?:\#\#\#\s*)?Metadata:\s*
                 (?:```json\s*)?
                 (\{.*?})
                 (?:\s*```)?
@@ -50,9 +50,9 @@ class SQLGenerator:
         if match:
             return match.group(1).strip()
         
-        # Fallback: look for '### SQL:' header
+        # Fallback: look for '### SQL:' or plain 'SQL:' header (model sometimes drops ### at high token counts)
         # Reluctant quantifier is intentional: match shortest content up to next section header or end
-        sql_header = re.search(r"### SQL:\s*(.+?)(?:\n###|\Z)", text, re.DOTALL) # NOSONAR
+        sql_header = re.search(r"(?:###\s*)?SQL:\s*(.+?)(?:\n(?:###\s*)?(?:Metadata:|Reasoning:)|\Z)", text, re.DOTALL) # NOSONAR
         if sql_header:
             return sql_header.group(1).strip()
         


### PR DESCRIPTION
Make ### prefix optional in SQL. The prompt ends with ### Reasoning: expecting the model to continue in ### SQL: / ### Metadata: format. But the model sometimes responded without ###: