### PR TITLE
Feature/ab#32906 reture actual table

### DIFF
--- a/applications/Unity.AI.Reporting.Backend/src/api.py
+++ b/applications/Unity.AI.Reporting.Backend/src/api.py
@@ -391,6 +391,33 @@ def _build_viz_settings(visualization_options: list) -> dict:
     return {}
 
 
+def _shape_card_data(card_data):
+    """Turn Metabase's `{cols, rows}` payload into the frontend preview shape.
+
+    Truncates rows to `config.app.preview_row_limit`. Returns None when the
+    payload is missing or malformed so the frontend can fall back to button-only.
+    """
+    if not isinstance(card_data, dict):
+        return None
+    cols = card_data.get("cols")
+    rows = card_data.get("rows")
+    if not isinstance(cols, list) or not isinstance(rows, list):
+        return None
+
+    limit = config.app.preview_row_limit
+    columns = [
+        (c.get("display_name") or c.get("name") or "") if isinstance(c, dict) else str(c)
+        for c in cols
+    ]
+    total_rows = len(rows)
+    return {
+        "columns": columns,
+        "rows": rows[:limit],
+        "total_rows": total_rows,
+        "truncated": total_rows > limit,
+    }
+
+
 def _fuzzy_cache_lookup(tenant_id, db_id, schema_types, collection_name, normalized_query):
     """Layer 1.5: rapidfuzz match against recent normalized queries."""
     recent = cache_repository.get_recent_normalized_queries(
@@ -527,7 +554,7 @@ async def _serve_cache_hit(cache_hit, db_id, collection_id, tenant_id):
         "exact_hit" if cache_hit["similarity"] >= 1.0 else "semantic_hit"
     )
     tokens_saved = cached.get("tokens", {}).get("total_tokens", 0)
-    card_id = metabase_client.create_card(
+    card_id, card_data = metabase_client.create_card(
         cached["sql"], db_id, collection_id, cached["title"],
         tenant_id=tenant_id,
         visualization_settings=_build_viz_settings(cached.get("visualization_options", [])),
@@ -554,6 +581,7 @@ async def _serve_cache_hit(cache_hit, db_id, collection_id, tenant_id):
         "visualization_options": cached.get("visualization_options", []),
         "SQL": cached["sql"],
         "tokens": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+        "card_data": _shape_card_data(card_data),
         "from_cache": True,
         "cache_similarity": round(cache_hit["similarity"], 4),
         "cache_hit_type": hit_type,
@@ -658,7 +686,7 @@ async def _async_ask(data, user_data):
     logger.debug(f"Metadata: {metadata}")
     logger.info(f"Creating Metabase card with SQL length: {len(sql)}")
 
-    card_id = metabase_client.create_card(
+    card_id, card_data = metabase_client.create_card(
         sql, db_id, collection_id, metadata['title'],
         tenant_id=tenant_id,
         visualization_settings=_build_viz_settings(metadata.get("visualization_options", [])),
@@ -681,6 +709,7 @@ async def _async_ask(data, user_data):
         "visualization_options": metadata.get('visualization_options', []),
         "SQL": sql,
         "tokens": sql_tokens,
+        "card_data": _shape_card_data(card_data),
     }, 200
 
 

--- a/applications/Unity.AI.Reporting.Backend/src/chat.py
+++ b/applications/Unity.AI.Reporting.Backend/src/chat.py
@@ -102,8 +102,8 @@ class ChatManager:
 
         title = embed_data.get('title', 'Untitled')
         try:
-            # Create new card
-            new_card_id = self.metabase.create_card(
+            # Create new card; card_data unused here (only restoring the card)
+            new_card_id, _ = self.metabase.create_card(
                 sql, db_id, collection_id, title,
                 tenant_id=tenant_id
             )

--- a/applications/Unity.AI.Reporting.Backend/src/config.py
+++ b/applications/Unity.AI.Reporting.Backend/src/config.py
@@ -93,7 +93,7 @@ class AppConfig:
     semantic_cache_top_k: int = 5
     llm_judge_enabled: bool = False
     llm_judge_score_threshold: float = 8.0
-    preview_row_limit: int = 100
+    preview_row_limit: int = 1000
 
 
 class Config:
@@ -145,7 +145,7 @@ class Config:
             semantic_cache_top_k=int(os.getenv("SEMANTIC_CACHE_TOP_K", "5")),
             llm_judge_enabled=os.getenv("LLM_JUDGE_ENABLED", "false").lower() == "true",
             llm_judge_score_threshold=float(os.getenv("LLM_JUDGE_SCORE_THRESHOLD", "8.0")),
-            preview_row_limit=int(os.getenv("PREVIEW_ROW_LIMIT", "100")),
+            preview_row_limit=int(os.getenv("PREVIEW_ROW_LIMIT", "1000")),
         )
         
         # Tenant configuration - extensible for different use cases

--- a/applications/Unity.AI.Reporting.Backend/src/config.py
+++ b/applications/Unity.AI.Reporting.Backend/src/config.py
@@ -93,6 +93,7 @@ class AppConfig:
     semantic_cache_top_k: int = 5
     llm_judge_enabled: bool = False
     llm_judge_score_threshold: float = 8.0
+    preview_row_limit: int = 100
 
 
 class Config:
@@ -144,6 +145,7 @@ class Config:
             semantic_cache_top_k=int(os.getenv("SEMANTIC_CACHE_TOP_K", "5")),
             llm_judge_enabled=os.getenv("LLM_JUDGE_ENABLED", "false").lower() == "true",
             llm_judge_score_threshold=float(os.getenv("LLM_JUDGE_SCORE_THRESHOLD", "8.0")),
+            preview_row_limit=int(os.getenv("PREVIEW_ROW_LIMIT", "100")),
         )
         
         # Tenant configuration - extensible for different use cases

--- a/applications/Unity.AI.Reporting.Backend/src/metabase.py
+++ b/applications/Unity.AI.Reporting.Backend/src/metabase.py
@@ -220,8 +220,8 @@ class MetabaseClient:
                     time.sleep(1)
 
             return body.get("data") if isinstance(body, dict) else None
-        except Exception as e:
-            logger.error(f"Error fetching card data for card {card_id}: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Error fetching card data for card %s", card_id)
             return None
     
     def update_card_visualization(self, card_id: int, display_mode: str,

--- a/applications/Unity.AI.Reporting.Backend/src/metabase.py
+++ b/applications/Unity.AI.Reporting.Backend/src/metabase.py
@@ -121,9 +121,10 @@ class MetabaseClient:
 
     def create_card(self, sql: str, db_id: int, collection_id: int,
                     name: str, tenant_id: Optional[str] = None,
-                    visualization_settings: Optional[Dict[str, Any]] = None) -> int:
+                    visualization_settings: Optional[Dict[str, Any]] = None
+                    ) -> Tuple[int, Optional[Dict[str, Any]]]:
         """
-        Create a new Metabase card (saved question).
+        Create a new Metabase card (saved question) and execute its query.
 
         Args:
             sql: SQL query for the card
@@ -133,7 +134,9 @@ class MetabaseClient:
             tenant_id: Optional tenant ID to use tenant-specific API key
 
         Returns:
-            Card ID
+            Tuple of (card_id, card_data) where card_data is the inner
+            `{"cols": [...], "rows": [...]}` dict from Metabase (same shape as
+            execute_sql), or None if the post-creation query failed.
         """
         headers = self._get_headers(tenant_id)
         url = f"{self.config.url}/api/card"
@@ -189,7 +192,37 @@ class MetabaseClient:
             logger.error(f"Response text: {r.text}")
             raise ValueError(f"Error parsing Metabase response: {e}")
 
-        return card_id
+        card_data = self._run_card_query(card_id, headers)
+        return card_id, card_data
+
+    def _run_card_query(self, card_id: int, headers: Dict[str, str]) -> Optional[Dict[str, Any]]:
+        """Execute a saved card and return its inner data dict.
+
+        Returns None on any failure so callers can fall back gracefully.
+        """
+        query_url = f"{self.config.url}/api/card/{card_id}/query"
+        try:
+            r = requests.post(query_url, headers=headers, json={"ignore_cache": True}, timeout=30)
+            body = r.json()
+
+            if r.status_code == 202 and body.get("status") == "running":
+                job_id = body.get("id")
+                deadline = time.time() + 30
+                while time.time() < deadline:
+                    jr = requests.get(
+                        f"{self.config.url}/api/async/{job_id}",
+                        headers=headers,
+                        timeout=10,
+                    )
+                    if jr.status_code == 200:
+                        body = jr.json()
+                        break
+                    time.sleep(1)
+
+            return body.get("data") if isinstance(body, dict) else None
+        except Exception as e:
+            logger.error(f"Error fetching card data for card {card_id}: {e}", exc_info=True)
+            return None
     
     def update_card_visualization(self, card_id: int, display_mode: str,
                                  x_fields: List[str], y_fields: List[str],

--- a/applications/Unity.AI.Reporting.Backend/src/sql_generator.py
+++ b/applications/Unity.AI.Reporting.Backend/src/sql_generator.py
@@ -340,10 +340,16 @@ class SQLGenerator:
             past_questions: List of past questions and SQL
             db_id: Database ID
             tenant_id: Optional tenant ID for tenant-specific Metabase API key
+            is_retry: Whether this call is a retry of a previously failed attempt
+            retry_error_type: Error type from the previous attempt, if retrying
+            retry_error_detail: Validation error detail from the previous attempt,
+                fed back into the prompt to guide a corrected query
 
         Returns:
-            Tuple of (sql, metadata, token_usage) or (None, None, None) if generation fails
-            where token_usage contains prompt_tokens, completion_tokens, total_tokens
+            Tuple of (sql, metadata, token_usage, error_detail). On failure the
+            leading elements are None; error_detail carries any validation error
+            text when no valid candidate could be generated.
+            token_usage contains prompt_tokens, completion_tokens, total_tokens.
         """
 
         # Check for hardcoded examples first (can be removed in production)
@@ -357,7 +363,7 @@ class SQLGenerator:
         schemas = self.embeddings.get_formatted_schemas(question, db_id)
         if not schemas:
             logger.error(f"No schemas found for db_id={db_id}. Embeddings may not have been generated yet.")
-            return None, None, None
+            return None, None, None, None
 
         # Generate multiple completions in parallel
         async with aiohttp.ClientSession() as session:
@@ -387,7 +393,8 @@ Output EXACTLY one word: RELATED or UNRELATED.
                 return None, None, None, None
 
             # Build prompt
-            prompt = self.build_prompt(question, schemas, past_questions, is_retry=is_retry, retry_error_type=retry_error_type)
+            prompt = self.build_prompt(question, schemas, past_questions, is_retry=is_retry,
+                                       retry_error_type=retry_error_type, retry_error_detail=retry_error_detail)
             logger.debug(f"Prompt: {prompt[:200]}...")
             tasks = [
                 self.fetch_completion(prompt, session, i)

--- a/applications/Unity.AI.Reporting.Frontend/angular.json
+++ b/applications/Unity.AI.Reporting.Frontend/angular.json
@@ -36,8 +36,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "8kB",
-                  "maximumError": "12kB"
+                  "maximumWarning": "14kB",
+                  "maximumError": "16kB"
                 }
               ],
               "outputHashing": "all",

--- a/applications/Unity.AI.Reporting.Frontend/src/app/app.css
+++ b/applications/Unity.AI.Reporting.Frontend/src/app/app.css
@@ -175,8 +175,8 @@
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
+  justify-content: flex-start;
+  align-items: stretch;
 }
 .bot-inner.loaded {
   opacity: 1;
@@ -874,7 +874,6 @@
   letter-spacing: 0.3px;
 }
 
-/* Secondary variant: shown beneath an inline result table */
 .metabase-view-container--secondary {
   justify-content: flex-end;
   margin-top: 12px;
@@ -894,22 +893,86 @@
   box-shadow: 0 3px 10px rgba(66, 153, 225, 0.3);
 }
 
-.metabase-view-btn--secondary svg {
-  width: 16px;
-  height: 16px;
+.result-header {
+  position: relative;
+  margin: 12px 0 12px;
+  padding: 0 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
 }
 
-/* ---------- Inline result table ---------- */
+.metabase-view-btn--header {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: 6px;
+  gap: 6px;
+  box-shadow: 0 1px 4px rgba(66, 153, 225, 0.25);
+}
+
+.result-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: #1a202c;
+  line-height: 1.3;
+  text-align: center;
+  max-width: calc(100% - 180px);
+}
+
+.result-question {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  gap: 4px;
+  padding: 4px 12px;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+  border-radius: 999px;
+  font-size: 12px;
+  color: #475569;
+  line-height: 1.4;
+}
+
+.result-question::before,
+.result-question::after {
+  content: "“";
+  font-size: 16px;
+  line-height: 1;
+  color: #94a3b8;
+  font-family: serif;
+  flex-shrink: 0;
+}
+
+.result-question::after {
+  content: "”";
+}
+
+.result-question-text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
 .result-table-wrapper {
-  max-height: 360px;
+  flex: 0 1 auto;
+  min-height: 0;
+  max-height: 380px;
   overflow: auto;
+  resize: vertical;
   border: 1px solid #e2e8f0;
   border-radius: 8px;
   background: #ffffff;
 }
 
 .result-table {
-  width: 100%;
+  min-width: 100%;
+  width: max-content;
   border-collapse: collapse;
   font-size: 13px;
   font-variant-numeric: tabular-nums;
@@ -924,7 +987,8 @@
   text-align: left;
   padding: 8px 12px;
   border-bottom: 1px solid #e2e8f0;
-  white-space: nowrap;
+  max-width: 240px;
+  word-break: break-word;
   z-index: 1;
 }
 
@@ -932,8 +996,8 @@
   padding: 6px 12px;
   border-bottom: 1px solid #edf2f7;
   color: #2d3748;
+  max-width: 240px;
   white-space: nowrap;
-  max-width: 320px;
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/applications/Unity.AI.Reporting.Frontend/src/app/app.css
+++ b/applications/Unity.AI.Reporting.Frontend/src/app/app.css
@@ -873,6 +873,87 @@
   z-index: 1;
   letter-spacing: 0.3px;
 }
+
+/* Secondary variant: shown beneath an inline result table */
+.metabase-view-container--secondary {
+  justify-content: flex-end;
+  margin-top: 12px;
+}
+
+.metabase-view-btn--secondary {
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  border-radius: 8px;
+  gap: 8px;
+  box-shadow: 0 2px 6px rgba(66, 153, 225, 0.25);
+}
+
+.metabase-view-btn--secondary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 3px 10px rgba(66, 153, 225, 0.3);
+}
+
+.metabase-view-btn--secondary svg {
+  width: 16px;
+  height: 16px;
+}
+
+/* ---------- Inline result table ---------- */
+.result-table-wrapper {
+  max-height: 360px;
+  overflow: auto;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.result-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+}
+
+.result-table thead th {
+  position: sticky;
+  top: 0;
+  background: #f7fafc;
+  color: #2d3748;
+  font-weight: 600;
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 1px solid #e2e8f0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.result-table tbody td {
+  padding: 6px 12px;
+  border-bottom: 1px solid #edf2f7;
+  color: #2d3748;
+  white-space: nowrap;
+  max-width: 320px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.result-table tbody tr:nth-child(even) td {
+  background: #fafbfc;
+}
+
+.result-table tbody tr:hover td {
+  background: #ebf8ff;
+}
+
+.result-truncation-note {
+  font-size: 12px;
+  color: #718096;
+  margin-top: 6px;
+  text-align: right;
+  font-style: italic;
+}
+
 .retry-hint {
   font-size: 0.9rem;
   color: #666;

--- a/applications/Unity.AI.Reporting.Frontend/src/app/app.css
+++ b/applications/Unity.AI.Reporting.Frontend/src/app/app.css
@@ -874,11 +874,6 @@
   letter-spacing: 0.3px;
 }
 
-.metabase-view-container--secondary {
-  justify-content: flex-end;
-  margin-top: 12px;
-}
-
 .metabase-view-btn--secondary {
   padding: 8px 16px;
   font-size: 13px;

--- a/applications/Unity.AI.Reporting.Frontend/src/app/app.html
+++ b/applications/Unity.AI.Reporting.Frontend/src/app/app.html
@@ -216,13 +216,6 @@
                   -->
                   @if (conversation.length > 0 && currentTurnIndex >= 0 && currentTurnIndex < conversation.length) {
                     <div class="action-buttons">
-                      <button class="action-button" (click)="redirectToMB(conversation[currentTurnIndex])" title="View in Metabase">
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                          <path d="M18 13V19C18 20.1046 17.1046 21 16 21H5C3.89543 21 3 20.1046 3 19V8C3 6.89543 3.89543 6 5 6H11" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                          <path d="M15 3H21V9" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                          <path d="M10 14L21 3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                        </svg>
-                      </button>
                       <button class="action-button" (click)="toggleSqlPanel(conversation[currentTurnIndex])" title="Show/Hide SQL">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                           <path d="M13 2L3 14H12L11 22L21 10H12L13 2Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/applications/Unity.AI.Reporting.Frontend/src/app/app.html
+++ b/applications/Unity.AI.Reporting.Frontend/src/app/app.html
@@ -145,7 +145,7 @@
                               @for (row of turn.embed.card_data.rows; track $index) {
                                 <tr>
                                   @for (cell of row; track $index) {
-                                    <td [title]="cell">{{ cell }}</td>
+                                    <td [title]="formatCell(cell)">{{ formatCell(cell) }}</td>
                                   }
                                 </tr>
                               }
@@ -157,8 +157,7 @@
                             Showing {{ turn.embed.card_data.rows.length }} of {{ turn.embed.card_data.total_rows }} rows. Open in Metabase to see the full result.
                           </div>
                         }
-                      }
-                      @if (!turn.embed.card_data || turn.embed.card_data.rows.length === 0) {
+                      } @else {
                         <div class="metabase-view-container">
                           <button class="metabase-view-btn" (click)="redirectToMB(turn)" title="View in Metabase">
                             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/applications/Unity.AI.Reporting.Frontend/src/app/app.html
+++ b/applications/Unity.AI.Reporting.Frontend/src/app/app.html
@@ -113,8 +113,39 @@
                           </button>
                         </div>
                       }
-                      <div class="metabase-view-container">
-                        <button class="metabase-view-btn" (click)="redirectToMB(turn)" title="View in Metabase">
+                      @if (turn.embed.card_data && turn.embed.card_data.rows.length > 0) {
+                        <div class="result-table-wrapper" role="region" aria-label="Query results preview">
+                          <table class="result-table">
+                            <thead>
+                              <tr>
+                                @for (col of turn.embed.card_data.columns; track col) {
+                                  <th>{{ col }}</th>
+                                }
+                              </tr>
+                            </thead>
+                            <tbody>
+                              @for (row of turn.embed.card_data.rows; track $index) {
+                                <tr>
+                                  @for (cell of row; track $index) {
+                                    <td>{{ cell }}</td>
+                                  }
+                                </tr>
+                              }
+                            </tbody>
+                          </table>
+                        </div>
+                        @if (turn.embed.card_data.truncated) {
+                          <div class="result-truncation-note">
+                            Showing {{ turn.embed.card_data.rows.length }} of {{ turn.embed.card_data.total_rows }} rows. Open in Metabase to see the full result.
+                          </div>
+                        }
+                      }
+                      <div class="metabase-view-container"
+                           [class.metabase-view-container--secondary]="!!turn.embed.card_data && turn.embed.card_data.rows.length > 0">
+                        <button class="metabase-view-btn"
+                                [class.metabase-view-btn--secondary]="!!turn.embed.card_data && turn.embed.card_data.rows.length > 0"
+                                (click)="redirectToMB(turn)"
+                                title="View in Metabase">
                           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <path d="M18 13V19C18 20.1046 17.1046 21 16 21H5C3.89543 21 3 20.1046 3 19V8C3 6.89543 3.89543 6 5 6H11" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                             <path d="M15 3H21V9" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/applications/Unity.AI.Reporting.Frontend/src/app/app.html
+++ b/applications/Unity.AI.Reporting.Frontend/src/app/app.html
@@ -114,6 +114,24 @@
                         </div>
                       }
                       @if (turn.embed.card_data && turn.embed.card_data.rows.length > 0) {
+                        <div class="result-header">
+                          <button class="metabase-view-btn metabase-view-btn--secondary metabase-view-btn--header"
+                                  (click)="redirectToMB(turn)"
+                                  title="View in Metabase">
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                              <path d="M18 13V19C18 20.1046 17.1046 21 16 21H5C3.89543 21 3 20.1046 3 19V8C3 6.89543 3.89543 6 5 6H11" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                              <path d="M15 3H21V9" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                              <path d="M10 14L21 3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                            </svg>
+                            <span>View in Metabase</span>
+                          </button>
+                          <div class="result-title">{{ turn.embed.title }}</div>
+                          @if (turn.question) {
+                            <div class="result-question" [title]="turn.question">
+                              <span class="result-question-text">{{ turn.question }}</span>
+                            </div>
+                          }
+                        </div>
                         <div class="result-table-wrapper" role="region" aria-label="Query results preview">
                           <table class="result-table">
                             <thead>
@@ -127,7 +145,7 @@
                               @for (row of turn.embed.card_data.rows; track $index) {
                                 <tr>
                                   @for (cell of row; track $index) {
-                                    <td>{{ cell }}</td>
+                                    <td [title]="cell">{{ cell }}</td>
                                   }
                                 </tr>
                               }
@@ -140,20 +158,18 @@
                           </div>
                         }
                       }
-                      <div class="metabase-view-container"
-                           [class.metabase-view-container--secondary]="!!turn.embed.card_data && turn.embed.card_data.rows.length > 0">
-                        <button class="metabase-view-btn"
-                                [class.metabase-view-btn--secondary]="!!turn.embed.card_data && turn.embed.card_data.rows.length > 0"
-                                (click)="redirectToMB(turn)"
-                                title="View in Metabase">
-                          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                            <path d="M18 13V19C18 20.1046 17.1046 21 16 21H5C3.89543 21 3 20.1046 3 19V8C3 6.89543 3.89543 6 5 6H11" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                            <path d="M15 3H21V9" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                            <path d="M10 14L21 3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                          </svg>
-                          <span>View Full Report in Metabase</span>
-                        </button>
-                      </div>
+                      @if (!turn.embed.card_data || turn.embed.card_data.rows.length === 0) {
+                        <div class="metabase-view-container">
+                          <button class="metabase-view-btn" (click)="redirectToMB(turn)" title="View in Metabase">
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                              <path d="M18 13V19C18 20.1046 17.1046 21 16 21H5C3.89543 21 3 20.1046 3 19V8C3 6.89543 3.89543 6 5 6H11" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                              <path d="M15 3H21V9" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                              <path d="M10 14L21 3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                            </svg>
+                            <span>View Full Report in Metabase</span>
+                          </button>
+                        </div>
+                      }
                       @if (turn.sqlPanelOpen) {
                         <div class="sql-panel">
                           <div class="sql-panel-header">Generated SQL</div>

--- a/applications/Unity.AI.Reporting.Frontend/src/app/app.html
+++ b/applications/Unity.AI.Reporting.Frontend/src/app/app.html
@@ -132,7 +132,7 @@
                             </div>
                           }
                         </div>
-                        <div class="result-table-wrapper" role="region" aria-label="Query results preview">
+                        <section class="result-table-wrapper" aria-label="Query results preview">
                           <table class="result-table">
                             <thead>
                               <tr>
@@ -151,7 +151,7 @@
                               }
                             </tbody>
                           </table>
-                        </div>
+                        </section>
                         @if (turn.embed.card_data.truncated) {
                           <div class="result-truncation-note">
                             Showing {{ turn.embed.card_data.rows.length }} of {{ turn.embed.card_data.total_rows }} rows. Open in Metabase to see the full result.

--- a/applications/Unity.AI.Reporting.Frontend/src/app/app.ts
+++ b/applications/Unity.AI.Reporting.Frontend/src/app/app.ts
@@ -1,7 +1,6 @@
 import { Component, ViewChild, ElementRef, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
 import { FormsModule } from '@angular/forms';
-import { DecimalPipe } from '@angular/common';
 import { SafeResourceUrl, DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
 import { Embed } from './embed';
@@ -20,7 +19,7 @@ import { environment } from '../environments/environment';
 
 @Component({
   selector: 'app-root',
-  imports: [FormsModule, DecimalPipe, SqlExplanationComponent, SidebarComponent, ToastComponent, AlertComponent],
+  imports: [FormsModule, SqlExplanationComponent, SidebarComponent, ToastComponent, AlertComponent],
   templateUrl: './app.html',
   styleUrls: ['./app.css']
 })

--- a/applications/Unity.AI.Reporting.Frontend/src/app/app.ts
+++ b/applications/Unity.AI.Reporting.Frontend/src/app/app.ts
@@ -330,24 +330,6 @@ export class App implements OnInit, OnDestroy {
     this.turnToDelete = null;
   }
 
-  // VISUALIZATION: Commented out - not functional since switching to Metabase redirect.
-  //               Restore when custom visualization is implemented.
-  // async changeDisplay(turn: Turn, mode: string) {
-  //   try {
-  //     await firstValueFrom(
-  //       this.apiService.changeDisplay<Embed>(turn.embed.card_id, mode, turn.embed.x_field, turn.embed.y_field)
-  //     );
-  //     // Update the current visualization in the embed
-  //     turn.embed.current_visualization = mode;
-  //   } catch (error) {
-  //     // Log the error and notify the user
-  //     this.logger.error('Error changing display mode:', error);
-  //     this.toastService.error('Failed to change display mode. Please try again.');
-  //   } finally {
-  //     this.cdr.markForCheck();
-  //   }
-  // }
-
   async resetConversation() {
     this.conversation = [];
     this.currentTurnIndex = 0;

--- a/applications/Unity.AI.Reporting.Frontend/src/app/app.ts
+++ b/applications/Unity.AI.Reporting.Frontend/src/app/app.ts
@@ -650,8 +650,9 @@ export class App implements OnInit, OnDestroy {
 
   formatCell(value: unknown): string {
     if (value === null || value === undefined) return '—';
-    if (typeof value === 'object') return JSON.stringify(value);
-    return String(value);
+    if (typeof value === 'string') return value;
+    if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+    return JSON.stringify(value);
   }
 
   highlightSql(sql: string): SafeHtml {

--- a/applications/Unity.AI.Reporting.Frontend/src/app/app.ts
+++ b/applications/Unity.AI.Reporting.Frontend/src/app/app.ts
@@ -648,6 +648,12 @@ export class App implements OnInit, OnDestroy {
   //   }
   // }
 
+  formatCell(value: unknown): string {
+    if (value === null || value === undefined) return '—';
+    if (typeof value === 'object') return JSON.stringify(value);
+    return String(value);
+  }
+
   highlightSql(sql: string): SafeHtml {
     if (!sql) return this.sanitizer.bypassSecurityTrustHtml('');
 

--- a/applications/Unity.AI.Reporting.Frontend/src/app/embed.ts
+++ b/applications/Unity.AI.Reporting.Frontend/src/app/embed.ts
@@ -16,4 +16,12 @@ export interface Embed {
     cache_similarity?: number;      // Cosine similarity score (0–1) of the cache hit
     cache_hit_type?: 'exact_hit' | 'semantic_hit' | 'fuzzy_hit' | 'llm_judge_hit';
     cache_original_query?: string;  // The original cached query (set for llm_judge_hit only)
+    card_data?: CardData | null;    // Inline preview rows from Metabase (null when fetch failed)
+}
+
+export interface CardData {
+    columns: string[];
+    rows: unknown[][];
+    total_rows: number;
+    truncated: boolean;
 }


### PR DESCRIPTION
Adds an inline result table to the AI reporting UI that renders rows returned by Metabase immediately after SQL generation, so users can see the query output without opening the embedded dashboard.