### PR TITLE
AB#32473 - Reduce OpenShift Env Var Injection to Secrets Only

### DIFF
--- a/applications/.env.example
+++ b/applications/.env.example
@@ -1,51 +1,42 @@
 # Unity AI Platform Environment Configuration Example
 # Copy this file to .env and update with your actual values
-
-## PLATFORM SETTINGS  
-UAI_BUILD_VERSION=0.1.0
-UAI_BUILD_REVISION=0000000
-UAI_TARGET_ENVIRONMENT=LocalDevelopment
+#
+# Non-sensitive config (deployment names, model versions, ports, UUIDs) is
+# hardcoded in config.py and the Dockerfile — do not add those here.
 
 ## DATABASE SETTINGS
-# PostgreSQL configuration with pgvector support (used by docker-compose.yml)
-POSTGRES_DB="UnityAI"
-POSTGRES_USER="uai_pguser"
-POSTGRES_PASSWORD="your_postgres_password_here"
+# Used by both the postgres container (via POSTGRES_* mapping in docker-compose) and the app
+DB_NAME="unity_ai"
+DB_USER="unity_user"
+DB_PASSWORD="your_postgres_password_here"
 
 ## UNITY.AI.REPORTING CONFIGURATION
 
-# Flask Environment (development, test, staging, or production)
+# Flask Environment — override the Dockerfile default (production) for local development
 FLASK_ENV="development"
 
-# Metabase Integration
-METABASE_KEY="your_metabase_api_key_here"
-MB_EMBED_SECRET="your_metabase_embed_secret_here"
-MB_URL="http://localhost:3000"
-DEFAULT_EMBED_DB_ID="5"
-MB_EMBED_ID="5"
+# --- SECRETS (required in OpenShift Secrets) ---
 
-# AI Model Configuration (Optional - defaults provided in docker-compose)
-AI_MODEL="gpt-4o-mini"
-EMBEDDING_MODEL="text-embedding-3-large"
-EMBED_WORKSHEETS="true"
+# Azure OpenAI — only the endpoint base URL and API key are injected at runtime
+AZURE_OPENAI_ENDPOINT="https://your-azure-openai-resource.openai.azure.com/"
+AZURE_OPENAI_API_KEY="your_azure_openai_api_key_here"
 
 # JWT Authentication
 # IMPORTANT: Generate a strong secret using: openssl rand -base64 64
 JWT_SECRET="your_jwt_secret_64_characters_minimum_here"
 
-# iframe Origin Security - Comma-separated list of allowed parent domains
+# Metabase secrets
+METABASE_KEY="your_metabase_api_key_here"
+MB_EMBED_SECRET="your_metabase_embed_secret_here"
+
+# --- ENV-SPECIFIC CONFIG (required in OpenShift ConfigMap) ---
+
+# Metabase base URL (differs per namespace)
+MB_URL="http://localhost:3000"
+
+# iframe Origin Security — comma-separated list of allowed parent domains
 # Include http://localhost for local development URL token access
-# Add production domains for PostMessage authentication in iframe
 ORIGIN_URL="http://localhost"
 
-# Azure OpenAI Configuration
-AZURE_OPENAI_ENDPOINT="https://your-azure-openai-resource.openai.azure.com/"
-AZURE_OPENAI_API_KEY="your_azure_openai_api_key_here"
-AZURE_OPENAI_DEPLOYMENT="gpt-4o-mini"
-AZURE_OPENAI_EMBEDDING_DEPLOYMENT="text-embedding-3-large"
-AZURE_OPENAI_API_VERSION="2024-02-01"
-
-## UNITY.AI.ASSESSMENT CONFIGURATION (Placeholder for future development)
-# UNITY_AI_ASSESSMENT_API_KEY="your_assessment_api_key"
-# UNITY_AI_ASSESSMENT_MODEL="your_assessment_model"
-# UNITY_AI_ASSESSMENT_ENDPOINT="your_assessment_endpoint"
+# Feature flags
+EMBED_WORKSHEETS="true"

--- a/applications/Dockerfile
+++ b/applications/Dockerfile
@@ -61,6 +61,9 @@ RUN pip install --no-cache-dir -r requirements.txt gunicorn && \
     chown appuser:appuser /entrypoint.sh && \
     chown -R appuser:appuser /app
 
+# Default to production; override via env var for local development
+ENV FLASK_ENV=production
+
 # Expose port 8080
 EXPOSE 8080
 

--- a/applications/Unity.AI.Reporting.Backend/src/api.py
+++ b/applications/Unity.AI.Reporting.Backend/src/api.py
@@ -387,7 +387,7 @@ def get_feedback_for_admin():
 def _build_viz_settings(visualization_options: list) -> dict:
     """Return Metabase visualization settings dict for the given options list."""
     if "map" in visualization_options:
-        return {"map.region": os.getenv("MB_MAP_REGION_UUID", "1c5d50ee-4389-4593-37c1-fa8d4687ff4c")}
+        return {"map.region": config.metabase.map_region_uuid}
     return {}
 
 

--- a/applications/Unity.AI.Reporting.Backend/src/config.py
+++ b/applications/Unity.AI.Reporting.Backend/src/config.py
@@ -37,37 +37,20 @@ class MetabaseConfig:
     api_key: str
     embed_secret: str
     default_db_id: int = 3
+    map_region_uuid: str = "1c5d50ee-4389-4593-37c1-fa8d4687ff4c"
     
 
 @dataclass
 class AIConfig:
     """AI/LLM configuration settings"""
-    # Azure OpenAI settings
+    # Azure OpenAI settings — only endpoint and key come from env vars
     azure_endpoint: str = ""
     azure_api_key: str = ""
-    azure_deployment: str = ""
-    azure_api_version: str = "2024-02-01"
-    azure_embedding_deployment: str = ""
-    
-    # Model settings
-    model: str = "gpt-4o-mini"
-    embedding_model: str = "text-embedding-3-large"
+    azure_deployment: str = "gpt-5-mini"
+    azure_api_version: str = "2024-10-21"
+    azure_embedding_deployment: str = "text-embedding-3-large"
     temperature: float = 0.2
     k_samples: int = 7
-    
-    # Legacy OpenAI settings (kept for compatibility)
-    completion_endpoint: str = ""
-    completion_key: str = ""
-    
-    @property
-    def use_azure(self) -> bool:
-        """Check if Azure OpenAI should be used"""
-        return bool(self.azure_endpoint and self.azure_api_key and self.azure_deployment)
-
-    @property
-    def use_azure_embeddings(self) -> bool:
-        """Check if Azure OpenAI embeddings should be used"""
-        return bool(self.azure_endpoint and self.azure_api_key and self.azure_embedding_deployment)
 
     @property
     def supports_temperature(self) -> bool:
@@ -102,7 +85,7 @@ class Config:
     def __init__(self):
         self.database = DatabaseConfig(
             host=os.getenv("DB_HOST", "localhost"),
-            port=os.getenv("DB_PORT", "5432"),
+            port="5432",
             name=os.getenv("DB_NAME", "unity_ai"),
             user=os.getenv("DB_USER", "unity_user"),
             password=os.getenv("DB_PASSWORD", "unity_pass")
@@ -116,18 +99,8 @@ class Config:
         )
         
         self.ai = AIConfig(
-            # Azure OpenAI settings
             azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT", ""),
             azure_api_key=os.getenv("AZURE_OPENAI_API_KEY", ""),
-            azure_deployment=os.getenv("AZURE_OPENAI_DEPLOYMENT", ""),
-            azure_api_version=os.getenv("AZURE_OPENAI_API_VERSION", "2024-02-01"),
-            azure_embedding_deployment=os.getenv("AZURE_OPENAI_EMBEDDING_DEPLOYMENT", ""),
-            # Model settings
-            model=os.getenv("AI_MODEL", "gpt-4o-mini"),
-            embedding_model=os.getenv("EMBEDDING_MODEL", "text-embedding-3-large"),
-            # Legacy OpenAI settings
-            completion_endpoint=os.getenv("COMPLETION_ENDPOINT", ""),
-            completion_key=os.getenv("COMPLETION_KEY", "")
         )
         
         flask_env = os.getenv("FLASK_ENV", "development")
@@ -171,13 +144,6 @@ class Config:
                         mappings = {"default": mappings}
 
                 print(f"Loaded tenant mappings from {config_file}: {mappings}")
-
-                # Override default db_id with environment variable if set
-                if "default" in mappings:
-                    env_db_id = os.getenv("DEFAULT_EMBED_DB_ID")
-                    if env_db_id:
-                        mappings["default"]["db_id"] = int(env_db_id)
-
                 return mappings
             except FileNotFoundError:
                 continue
@@ -186,7 +152,7 @@ class Config:
         print("No tenant_config.json found, using hardcoded defaults")
         return {
             "default": {
-                "db_id": int(os.getenv("DEFAULT_EMBED_DB_ID", "5")),
+                "db_id": 5,
                 "collection_id": 16,
                 "schema_types": ["public"]
             }

--- a/applications/Unity.AI.Reporting.Backend/src/custom_fields.py
+++ b/applications/Unity.AI.Reporting.Backend/src/custom_fields.py
@@ -1,12 +1,8 @@
-import os
 import json
-import dotenv
 import textwrap
 import requests
 import logging
 from config import config
-
-dotenv.load_dotenv()
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -35,12 +31,12 @@ def get_sql(sql, db_id, metabase_url, tenant_id=None):
 
 def get_worksheets():
     sql = 'SELECT "Worksheets"."Name", "Worksheets"."Id" FROM "Flex"."Worksheets"'
-    data = get_sql(sql, int(os.getenv("MB_EMBED_ID", "3")), os.getenv("MB_URL"))
+    data = get_sql(sql, config.metabase.default_db_id, config.metabase.url)
     return [{"name": r[0], "id": r[1]} for r in data["rows"]]
 
 def get_worksheet_instances(worksheet_id):
     sql = f'SELECT "WorksheetInstances"."CurrentValue", "WorksheetInstances"."WorksheetCorrelationId" FROM "Flex"."WorksheetInstances" WHERE "WorksheetInstances"."WorksheetId" = \'{worksheet_id}\''
-    data = get_sql(sql, int(os.getenv("MB_EMBED_ID", "3")), os.getenv("MB_URL"))
+    data = get_sql(sql, config.metabase.default_db_id, config.metabase.url)
     return data
 
 def get_custom_labels():
@@ -55,7 +51,7 @@ def get_custom_labels():
         ORDER BY "CustomFields"."Key"
         LIMIT {batch_size} OFFSET {offset}
         '''
-        rows = get_sql(sql, int(os.getenv("MB_EMBED_ID", "3")), os.getenv("MB_URL"))["rows"]
+        rows = get_sql(sql, config.metabase.default_db_id, config.metabase.url)["rows"]
 
         if not rows:
             break
@@ -100,7 +96,7 @@ _(none)_
 
 def get_column_example(table, column):
     sql = f"SELECT \"{column}\" FROM \"Reporting\".\"{table}\" WHERE \"{column}\" IS NOT null and \"{column}\" <> ''"
-    instance = get_sql(sql, int(os.getenv("MB_EMBED_ID", "3")), os.getenv("MB_URL"))
+    instance = get_sql(sql, config.metabase.default_db_id, config.metabase.url)
     try:
         return instance["rows"][0][0]
     except (KeyError, IndexError, TypeError):
@@ -120,7 +116,7 @@ def _format_table_schema(table_name, cols):
 
 def get_views_schemas():
     schema = requests.get(
-        f"{os.getenv('MB_URL')}/api/database/{os.getenv('MB_EMBED_ID')}/metadata",
+        f"{config.metabase.url}/api/database/{config.metabase.default_db_id}/metadata",
         headers=_get_headers()
     ).json()
 
@@ -143,7 +139,7 @@ def get_views_schemas():
 
         # Find out if there are non-blank rows
         sql = f"SELECT * FROM \"Reporting\".\"{tbl['name']}\" "
-        instance = get_sql(sql, int(os.getenv("MB_EMBED_ID", "3")), os.getenv("MB_URL"))
+        instance = get_sql(sql, config.metabase.default_db_id, config.metabase.url)
         rows = [r for r in instance["rows"] if set(r[3:]) != set([''])]
         if not rows:
             continue

--- a/applications/Unity.AI.Reporting.Backend/src/embeddings.py
+++ b/applications/Unity.AI.Reporting.Backend/src/embeddings.py
@@ -6,7 +6,7 @@ import logging
 import time
 from typing import List, Optional
 from langchain_core.documents import Document
-from langchain_openai import OpenAIEmbeddings, AzureOpenAIEmbeddings
+from langchain_openai import AzureOpenAIEmbeddings
 from pydantic import SecretStr
 from langchain_postgres import PGVector
 from config import config
@@ -197,19 +197,12 @@ class EmbeddingManager:
     """Manages vector embeddings for schema similarity search"""
 
     def __init__(self):
-        # Initialize embeddings model based on configuration
-        if config.ai.use_azure:
-            self.embedding_model = AzureOpenAIEmbeddings(
-                azure_endpoint=config.ai.azure_endpoint,
-                api_key=SecretStr(config.ai.azure_api_key),
-                azure_deployment=config.ai.azure_embedding_deployment,
-                api_version=config.ai.azure_api_version
-            )
-        else:
-            self.embedding_model = OpenAIEmbeddings(
-                model=config.ai.embedding_model,
-                api_key=SecretStr(config.ai.completion_key)
-            )
+        self.embedding_model = AzureOpenAIEmbeddings(
+            azure_endpoint=config.ai.azure_endpoint,
+            api_key=SecretStr(config.ai.azure_api_key),
+            azure_deployment=config.ai.azure_embedding_deployment,
+            api_version=config.ai.azure_api_version
+        )
 
         self.vector_store = PGVector(
             embeddings=self.embedding_model,

--- a/applications/Unity.AI.Reporting.Backend/src/metabase.py
+++ b/applications/Unity.AI.Reporting.Backend/src/metabase.py
@@ -250,7 +250,7 @@ class MetabaseClient:
                 "pie.metric": y_fields[0] if y_fields else ""
             })
         elif display_mode == "map":
-            visualization_settings["map.region"] = os.getenv("MB_MAP_REGION_UUID", "1c5d50ee-4389-4593-37c1-fa8d4687ff4c")
+            visualization_settings["map.region"] = config.metabase.map_region_uuid
 
         r = requests.put(
             f"{self.config.url}/api/card/{card_id}",

--- a/applications/Unity.AI.Reporting.Backend/src/sql_generator.py
+++ b/applications/Unity.AI.Reporting.Backend/src/sql_generator.py
@@ -105,40 +105,21 @@ class SQLGenerator:
         """
         logger.debug(f"[{index}] Tokens in prompt: {len(self.tokenizer.encode(prompt))}")
 
-        if self.config.use_azure:
-            # Use Azure OpenAI
-            headers = {
-                "api-key": self.config.azure_api_key,
-                "Content-Type": CONTENT_TYPE
-            }
-            
-            endpoint = f"{self.config.azure_endpoint}/openai/deployments/{self.config.azure_deployment}/chat/completions?api-version={self.config.azure_api_version}"
-            
-            json_data = {
-                "messages": [
-                    {"role": "system", "content": system_message},
-                    {"role": "user", "content": prompt}
-                ]
-            }
-            if self.config.supports_temperature:
-                json_data["temperature"] = self.config.temperature
-        else:
-            # Use standard OpenAI
-            headers = {
-                "Authorization": f"Bearer {self.config.completion_key}",
-                "Content-Type": CONTENT_TYPE
-            }
+        headers = {
+            "api-key": self.config.azure_api_key,
+            "Content-Type": CONTENT_TYPE
+        }
 
-            endpoint = self.config.completion_endpoint
+        endpoint = f"{self.config.azure_endpoint}/openai/deployments/{self.config.azure_deployment}/chat/completions?api-version={self.config.azure_api_version}"
 
-            json_data = {
-                "model": self.config.model,
-                "messages": [
-                    {"role": "system", "content": system_message},
-                    {"role": "user", "content": prompt}
-                ],
-                "temperature": self.config.temperature
-            }
+        json_data: Dict[str, Any] = {
+            "messages": [
+                {"role": "system", "content": system_message},
+                {"role": "user", "content": prompt}
+            ]
+        }
+        if self.config.supports_temperature:
+            json_data["temperature"] = self.config.temperature
         
         async with session.post(
             endpoint,
@@ -584,40 +565,21 @@ ORDER BY
 
 {sql}"""
             
-            if self.config.use_azure:
-                # Use Azure OpenAI
-                headers = {
-                    "api-key": self.config.azure_api_key,
-                    "Content-Type": CONTENT_TYPE
-                }
-                
-                endpoint = f"{self.config.azure_endpoint}/openai/deployments/{self.config.azure_deployment}/chat/completions?api-version={self.config.azure_api_version}"
-                
-                json_data = {
-                    "messages": [
-                        {"role": "system", "content": "You are a helpful assistant that explains SQL queries in simple terms."},
-                        {"role": "user", "content": prompt}
-                    ]
-                }
-                if self.config.supports_temperature:
-                    json_data["temperature"] = 0.3
-            else:
-                # Use standard OpenAI
-                headers = {
-                    "Authorization": f"Bearer {self.config.completion_key}",
-                    "Content-Type": CONTENT_TYPE
-                }
-                
-                endpoint = self.config.completion_endpoint
-                
-                json_data = {
-                    "model": "gpt-4o-mini",
-                    "messages": [
-                        {"role": "system", "content": "You are a helpful assistant that explains SQL queries in simple terms."},
-                        {"role": "user", "content": prompt}
-                    ],
-                    "temperature": 0.3
-                }
+            headers = {
+                "api-key": self.config.azure_api_key,
+                "Content-Type": CONTENT_TYPE
+            }
+
+            endpoint = f"{self.config.azure_endpoint}/openai/deployments/{self.config.azure_deployment}/chat/completions?api-version={self.config.azure_api_version}"
+
+            json_data: Dict[str, Any] = {
+                "messages": [
+                    {"role": "system", "content": "You are a helpful assistant that explains SQL queries in simple terms."},
+                    {"role": "user", "content": prompt}
+                ]
+            }
+            if self.config.supports_temperature:
+                json_data["temperature"] = 0.3
             
             async with aiohttp.ClientSession() as session:
                 async with session.post(

--- a/applications/docker-compose.yml
+++ b/applications/docker-compose.yml
@@ -6,9 +6,9 @@ services:
   postgres:
     image: pgvector/pgvector:pg17
     environment:
-      POSTGRES_DB: ${POSTGRES_DB:-unity_ai}
-      POSTGRES_USER: ${POSTGRES_USER:-unity_user}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${DB_NAME:-unity_ai}
+      POSTGRES_USER: ${DB_USER:-unity_user}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
     ports:
       - "5432:5432"
     volumes:
@@ -16,7 +16,7 @@ services:
     networks:
       - unity-ai-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-unity_user} -d ${POSTGRES_DB:-unity_ai}"]
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-unity_user} -d ${DB_NAME:-unity_ai}"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -34,42 +34,30 @@ services:
     ports:
       - "80:8080"
     environment:
-      # Build/Environment config
-      - UAI_TARGET_ENVIRONMENT=${UAI_TARGET_ENVIRONMENT:-Development}
-
       # Flask config
       - FLASK_ENV=${FLASK_ENV:-development}
 
-      # Azure OpenAI config
+      # Azure OpenAI secrets (all other Azure config is hardcoded in config.py)
       - AZURE_OPENAI_ENDPOINT=${AZURE_OPENAI_ENDPOINT}
       - AZURE_OPENAI_API_KEY=${AZURE_OPENAI_API_KEY}
-      - AZURE_OPENAI_DEPLOYMENT=${AZURE_OPENAI_DEPLOYMENT}
-      - AZURE_OPENAI_EMBEDDING_DEPLOYMENT=${AZURE_OPENAI_EMBEDDING_DEPLOYMENT}
-      - AZURE_OPENAI_API_VERSION=${AZURE_OPENAI_API_VERSION}
 
       # Authentication
       - JWT_SECRET=${JWT_SECRET}
       - ORIGIN_URL=${ORIGIN_URL}
 
-      # Metabase config
+      # Metabase config (secrets + env-specific base URL)
       - METABASE_KEY=${METABASE_KEY}
       - MB_EMBED_SECRET=${MB_EMBED_SECRET}
       - MB_URL=${MB_URL}
-      - DEFAULT_EMBED_DB_ID=${DEFAULT_EMBED_DB_ID:-5}
-      - MB_EMBED_ID=${MB_EMBED_ID}
-      - MB_MAP_REGION_UUID=${MB_MAP_REGION_UUID}
 
-      # Alternative (optional) AI Model config
-      - AI_MODEL=${AI_MODEL:-gpt-4o-mini}
-      - EMBEDDING_MODEL=${EMBEDDING_MODEL:-text-embedding-3-large}
+      # Feature flags
       - EMBED_WORKSHEETS=${EMBED_WORKSHEETS:-true}
 
       # Database config
       - DB_HOST=postgres
-      - DB_PORT=5432
-      - DB_NAME=${POSTGRES_DB:-unity_ai}
-      - DB_USER=${POSTGRES_USER:-unity_user}
-      - DB_PASSWORD=${POSTGRES_PASSWORD}
+      - DB_NAME=${DB_NAME:-unity_ai}
+      - DB_USER=${DB_USER:-unity_user}
+      - DB_PASSWORD=${DB_PASSWORD}
     depends_on:
       postgres:
         condition: service_healthy

--- a/applications/entrypoint.sh
+++ b/applications/entrypoint.sh
@@ -1,33 +1,6 @@
 #!/bin/sh
 set -e
 
-if [ "$UAI_TARGET_ENVIRONMENT" = "Local" ]; then
-    echo "Generating tenant_config.json from environment variables..."
-
-    # Generate tenant_config.json using Python (use 'python' not 'python3' in python:3.11-slim)
-    python -c "import json
-import os
-
-config = {
-    'default': {
-        'db_id': int(os.getenv('DEFAULT_EMBED_DB_ID', '5')),
-        'collection_id': 19,
-        'schema_types': ['public'],
-        'api_key': os.getenv('METABASE_KEY', '')
-    }
-}
-
-with open('/app/backend/src/tenant_config.json', 'w') as f:
-    json.dump(config, f, indent=2)
-"
-
-    echo "tenant_config.json created successfully"
-    cat /app/backend/src/tenant_config.json
-    echo ""
-else
-    echo "Tenant Config not written..."
-fi
-
 echo "Starting Flask application (serving static + API) on port 8080..."
 
 cd /app/backend/src


### PR DESCRIPTION
Refactors Unity AI Reporting configuration so OpenShift only needs to inject secrets and environment-specific base URLs. All non-sensitive, deployment-invariant settings are now hardcoded in `config.py` or the `Dockerfile`.