### PR TITLE
Feature/ab#32473 reduce open shift env injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ chroma_db/
 
 # Unity AI specific
 embedded_schema/
+tenant_config.local.json
 
 # Claude Code
 .claude/

--- a/applications/.env.example
+++ b/applications/.env.example
@@ -35,7 +35,8 @@ JWT_SECRET="your_jwt_secret_64_characters_minimum_here"
 MB_URL="http://localhost:3000"
 
 # Metabase internal UUID for the Regional Districts boundary layer (differs per Metabase instance)
-MB_MAP_REGION_UUID="1c5d50ee-4389-4593-37c1-fa8d4687ff4c"
+# Find it in Metabase Admin → Databases → your DB → map settings
+MB_MAP_REGION_UUID="your_regional_districts_uuid_here"
 
 # iframe Origin Security — comma-separated list of allowed parent domains
 # Include http://localhost for local development URL token access

--- a/applications/.env.example
+++ b/applications/.env.example
@@ -1,7 +1,7 @@
 # Unity AI Platform Environment Configuration Example
 # Copy this file to .env and update with your actual values
 #
-# Non-sensitive config (deployment names, model versions, ports, UUIDs) is
+# Non-sensitive config (deployment names, model versions, ports) is
 # hardcoded in config.py and the Dockerfile — do not add those here.
 
 ## DATABASE SETTINGS
@@ -33,6 +33,9 @@ MB_EMBED_SECRET="your_metabase_embed_secret_here"
 
 # Metabase base URL (differs per namespace)
 MB_URL="http://localhost:3000"
+
+# Metabase internal UUID for the Regional Districts boundary layer (differs per Metabase instance)
+MB_MAP_REGION_UUID="1c5d50ee-4389-4593-37c1-fa8d4687ff4c"
 
 # iframe Origin Security — comma-separated list of allowed parent domains
 # Include http://localhost for local development URL token access

--- a/applications/.env.example
+++ b/applications/.env.example
@@ -26,7 +26,8 @@ AZURE_OPENAI_API_KEY="your_azure_openai_api_key_here"
 JWT_SECRET="your_jwt_secret_64_characters_minimum_here"
 
 # Metabase secrets
-METABASE_KEY="your_metabase_api_key_here"
+# Note: Metabase API key (api_key) is NOT set here — put it in tenant_config.local.json
+# so it stays out of version control. See docker-compose.override.yml.example.
 MB_EMBED_SECRET="your_metabase_embed_secret_here"
 
 # --- ENV-SPECIFIC CONFIG (required in OpenShift ConfigMap) ---

--- a/applications/.env.example
+++ b/applications/.env.example
@@ -28,7 +28,6 @@ JWT_SECRET="your_jwt_secret_64_characters_minimum_here"
 # Metabase secrets
 # Note: Metabase API key (api_key) is NOT set here — put it in tenant_config.local.json
 # so it stays out of version control. See docker-compose.override.yml.example.
-MB_EMBED_SECRET="your_metabase_embed_secret_here"
 
 # --- ENV-SPECIFIC CONFIG (required in OpenShift ConfigMap) ---
 

--- a/applications/.env.example
+++ b/applications/.env.example
@@ -40,6 +40,3 @@ MB_MAP_REGION_UUID="1c5d50ee-4389-4593-37c1-fa8d4687ff4c"
 # iframe Origin Security — comma-separated list of allowed parent domains
 # Include http://localhost for local development URL token access
 ORIGIN_URL="http://localhost"
-
-# Feature flags
-EMBED_WORKSHEETS="true"

--- a/applications/README.md
+++ b/applications/README.md
@@ -44,8 +44,7 @@ AZURE_OPENAI_API_KEY=your_api_key
 JWT_SECRET=your_jwt_secret_64_chars_minimum
 ORIGIN_URL=https://your-parent-domain.com,http://localhost
 
-# Metabase — DB ID is derived from tenant_config.json, not an env var
-METABASE_KEY=your_metabase_api_key
+# Metabase — API key lives in tenant_config.local.json (gitignored), not here
 MB_EMBED_SECRET=your_metabase_embed_secret
 MB_URL=https://your-metabase-instance.com
 MB_MAP_REGION_UUID=your_metabase_regional_districts_uuid

--- a/applications/README.md
+++ b/applications/README.md
@@ -45,7 +45,6 @@ JWT_SECRET=your_jwt_secret_64_chars_minimum
 ORIGIN_URL=https://your-parent-domain.com,http://localhost
 
 # Metabase — API key lives in tenant_config.local.json (gitignored), not here
-MB_EMBED_SECRET=your_metabase_embed_secret
 MB_URL=https://your-metabase-instance.com
 MB_MAP_REGION_UUID=your_metabase_regional_districts_uuid
 

--- a/applications/README.md
+++ b/applications/README.md
@@ -36,24 +36,24 @@ Copy `.env.example` to `.env` and configure required variables:
 
 ### Critical Variables (Must Set)
 ```env
-# Azure OpenAI
+# Azure OpenAI — endpoint and key only; deployment names and versions are hardcoded in config.py
 AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com/
 AZURE_OPENAI_API_KEY=your_api_key
-AZURE_OPENAI_DEPLOYMENT=gpt-4o-mini
-AZURE_OPENAI_EMBEDDING_DEPLOYMENT=text-embedding-3-large
 
-# Authentication  
+# Authentication
 JWT_SECRET=your_jwt_secret_64_chars_minimum
 ORIGIN_URL=https://your-parent-domain.com,http://localhost
 
-# Metabase
+# Metabase — DB ID is derived from tenant_config.json, not an env var
 METABASE_KEY=your_metabase_api_key
 MB_EMBED_SECRET=your_metabase_embed_secret
 MB_URL=https://your-metabase-instance.com
-MB_EMBED_ID=5
+MB_MAP_REGION_UUID=your_metabase_regional_districts_uuid
 
-# Database
-POSTGRES_PASSWORD=your_secure_password
+# Database — shared by app and postgres container
+DB_NAME=unity_ai
+DB_USER=unity_user
+DB_PASSWORD=your_secure_password
 ```
 
 ### Platform Variables
@@ -144,12 +144,7 @@ docker push your-registry/unity-ai-reporting:latest
 
 ### Environment-Specific Configuration
 
-The application supports multiple deployment environments with different configurations:
-
-- **Development**: Local development with debug enabled
-- **Test**: Testing environment with test database (DB_ID=3)
-- **UAT**: User acceptance testing (DB_ID=5, FLASK_ENV=staging)  
-- **Production**: Production environment (DB_ID=3, FLASK_ENV=production)
+The application supports multiple deployment environments. Non-sensitive configuration (deployment names, model versions, DB IDs) is hardcoded in `config.py` or derived from `tenant_config.json`. Only secrets and base URLs need to be injected at runtime.
 
 See [Environment Configuration Guide](../documentation/unity-ai-reporting-environment-specific-configuration.md) for details.
 

--- a/applications/Unity.AI.Reporting.Backend/README.md
+++ b/applications/Unity.AI.Reporting.Backend/README.md
@@ -59,25 +59,21 @@ Server runs on `http://localhost:5000`
 Required variables (see `applications/.env.example`):
 
 ```env
-# Azure OpenAI
+# Azure OpenAI — endpoint and key only; deployment names, versions are hardcoded in config.py
 AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com/
 AZURE_OPENAI_API_KEY=your_key
-AZURE_OPENAI_DEPLOYMENT=gpt-4o-mini
-AZURE_OPENAI_EMBEDDING_DEPLOYMENT=text-embedding-3-large
-AZURE_OPENAI_API_VERSION=2024-02-15-preview
 
 # JWT Authentication
 JWT_SECRET=your_secure_secret_key
 
-# Metabase
+# Metabase — DB ID is derived from tenant_config.json
 METABASE_KEY=your_metabase_api_key
 MB_EMBED_SECRET=your_metabase_embed_secret
 MB_URL=https://your-metabase-url.com
-DEFAULT_EMBED_DB_ID=3
+MB_MAP_REGION_UUID=your_metabase_regional_districts_uuid
 
-# Database
+# Database — port is hardcoded to 5432
 DB_HOST=postgres
-DB_PORT=5432
 DB_NAME=unity_ai
 DB_USER=unity_user
 DB_PASSWORD=your_secure_password
@@ -118,7 +114,7 @@ DB_PASSWORD=your_secure_password
 
 - `app.py` - Application entry point, CLI commands
 - `api.py` - Flask routes and endpoints
-- `static_routes.py` - **NEW**: Serves Angular static files
+- `static_routes.py` - Serves Angular static files
 - `auth.py` - JWT authentication middleware
 - `config.py` - Configuration management
 - `database.py` - Database operations and repositories

--- a/applications/Unity.AI.Reporting.Backend/README.md
+++ b/applications/Unity.AI.Reporting.Backend/README.md
@@ -67,7 +67,6 @@ AZURE_OPENAI_API_KEY=your_key
 JWT_SECRET=your_secure_secret_key
 
 # Metabase — API key lives in tenant_config.local.json (gitignored), not here
-MB_EMBED_SECRET=your_metabase_embed_secret
 MB_URL=https://your-metabase-url.com
 MB_MAP_REGION_UUID=your_metabase_regional_districts_uuid
 

--- a/applications/Unity.AI.Reporting.Backend/README.md
+++ b/applications/Unity.AI.Reporting.Backend/README.md
@@ -66,8 +66,7 @@ AZURE_OPENAI_API_KEY=your_key
 # JWT Authentication
 JWT_SECRET=your_secure_secret_key
 
-# Metabase — DB ID is derived from tenant_config.json
-METABASE_KEY=your_metabase_api_key
+# Metabase — API key lives in tenant_config.local.json (gitignored), not here
 MB_EMBED_SECRET=your_metabase_embed_secret
 MB_URL=https://your-metabase-url.com
 MB_MAP_REGION_UUID=your_metabase_regional_districts_uuid

--- a/applications/Unity.AI.Reporting.Backend/src/app.py
+++ b/applications/Unity.AI.Reporting.Backend/src/app.py
@@ -34,7 +34,7 @@ def embed_schemas_command(db_id: Optional[int] = None):
     if tenant_config:
         schema_types = tenant_config.get("schema_types", ["public"])
     else:
-        schema_types = ["public", "custom"] if config.app.embed_worksheets else ["public"]
+        schema_types = ["public"]
 
     embedding_manager.embed_schemas(db_id, schema_types, tenant_id=matched_tenant_id)
     logger.info("Finished embedding process.")

--- a/applications/Unity.AI.Reporting.Backend/src/auth.py
+++ b/applications/Unity.AI.Reporting.Backend/src/auth.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta, timezone
 from functools import wraps
 from flask import abort, g, request, jsonify
 from typing import Optional, Dict, Any, Callable
+from config import DEFAULT_TENANT
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -75,7 +76,7 @@ class AuthManager:
 
             # If tenant is missing, use default
             if 'tenant' not in payload:
-                payload['tenant'] = 'default'
+                payload['tenant'] = DEFAULT_TENANT
 
             return payload
         except jwt.ExpiredSignatureError:

--- a/applications/Unity.AI.Reporting.Backend/src/config.py
+++ b/applications/Unity.AI.Reporting.Backend/src/config.py
@@ -36,10 +36,9 @@ class DatabaseConfig:
 class MetabaseConfig:
     """Metabase API configuration"""
     url: str
-    api_key: str
     embed_secret: str
-    default_db_id: int = 5
-    map_region_uuid: str = "1c5d50ee-4389-4593-37c1-fa8d4687ff4c"
+    default_db_id: int
+    map_region_uuid: str
     
 
 @dataclass
@@ -98,7 +97,6 @@ class Config:
 
         self.metabase = MetabaseConfig(
             url=os.getenv("MB_URL", ""),
-            api_key=os.getenv("METABASE_KEY", ""),
             embed_secret=os.getenv("MB_EMBED_SECRET", ""),
             default_db_id=default_db_id,
             map_region_uuid=os.getenv("MB_MAP_REGION_UUID") or "1c5d50ee-4389-4593-37c1-fa8d4687ff4c",
@@ -130,22 +128,41 @@ class Config:
         """
         Load tenant to database/collection mappings from JSON file.
         Falls back to default configuration if file is not found.
+        A tenant_config.local.json alongside the base file is merged on top
+        (per-tenant key override) and is never committed — use it for local
+        secrets like api_key.
         """
 
         # Try Docker path first, then local path (same directory as this file)
-        config_paths = [
-            "/app/backend/src/tenant_config.json",  # Docker container path
-            Path(__file__).parent / "tenant_config.json"  # Local development path
+        config_path_pairs = [
+            (
+                "/app/backend/src/tenant_config.json",
+                "/app/backend/src/tenant_config.local.json",
+            ),
+            (
+                Path(__file__).parent / "tenant_config.json",
+                Path(__file__).parent / "tenant_config.local.json",
+            ),
         ]
 
-        for config_file in config_paths:
+        for config_file, local_override_file in config_path_pairs:
             try:
                 with open(config_file, 'r') as f:
                     mappings = json.load(f)
                     if DEFAULT_TENANT not in mappings.keys():
                         mappings = {DEFAULT_TENANT: mappings}
 
-                print(f"Loaded tenant mappings from {config_file}: {mappings}")
+                if Path(local_override_file).is_file():
+                    with open(local_override_file, 'r') as f:
+                        overrides = json.load(f)
+                        for tenant, values in overrides.items():
+                            if tenant in mappings:
+                                mappings[tenant].update(values)
+                            else:
+                                mappings[tenant] = values
+                    print(f"Applied local tenant overrides from {local_override_file}")
+
+                print(f"Loaded tenant mappings from {config_file}")
                 return mappings
             except FileNotFoundError:
                 continue
@@ -165,14 +182,9 @@ class Config:
         return self.tenant_mappings.get(tenant_id, self.tenant_mappings[DEFAULT_TENANT])
 
     def get_tenant_metabase_headers(self, tenant_id: str) -> Dict[str, str]:
-        """
-        Get Metabase API headers for a specific tenant.
-        Uses tenant-specific API key from config file if available,
-        otherwise falls back to global METABASE_KEY from environment.
-        """
+        """Get Metabase API headers for a specific tenant using its api_key from tenant config."""
         tenant_config = self.get_tenant_config(tenant_id)
-        api_key = tenant_config.get("api_key", "") or self.metabase.api_key
-        return {"x-api-key": api_key}
+        return {"x-api-key": tenant_config.get("api_key", "")}
 
     @property
     def metabase_headers(self) -> Dict[str, str]:

--- a/applications/Unity.AI.Reporting.Backend/src/config.py
+++ b/applications/Unity.AI.Reporting.Backend/src/config.py
@@ -65,7 +65,6 @@ class AppConfig:
     flask_env: str
     debug: bool
     testing: bool
-    embed_worksheets: bool = False
     collection_name: str = "embedded_schema"
     semantic_cache_enabled: bool = True
     semantic_cache_threshold: float = 0.95
@@ -109,7 +108,6 @@ class Config:
             flask_env=flask_env,
             debug=flask_env != "production",
             testing=False,
-            embed_worksheets=os.getenv("EMBED_WORKSHEETS", "true").lower() == "true",
             semantic_cache_enabled=os.getenv("SEMANTIC_CACHE_ENABLED", "true").lower() == "true",
             semantic_cache_threshold=float(os.getenv("SEMANTIC_CACHE_THRESHOLD", "0.95")),
             fuzzy_match_enabled=os.getenv("FUZZY_MATCH_ENABLED", "true").lower() == "true",

--- a/applications/Unity.AI.Reporting.Backend/src/config.py
+++ b/applications/Unity.AI.Reporting.Backend/src/config.py
@@ -95,7 +95,8 @@ class Config:
             url=os.getenv("MB_URL", ""),
             api_key=os.getenv("METABASE_KEY", ""),
             embed_secret=os.getenv("MB_EMBED_SECRET", ""),
-            default_db_id=int(os.getenv("MB_EMBED_ID", "3"))
+            default_db_id=int(os.getenv("MB_EMBED_ID", "3")),
+            map_region_uuid=os.getenv("MB_MAP_REGION_UUID", "1c5d50ee-4389-4593-37c1-fa8d4687ff4c"),
         )
         
         self.ai = AIConfig(

--- a/applications/Unity.AI.Reporting.Backend/src/config.py
+++ b/applications/Unity.AI.Reporting.Backend/src/config.py
@@ -97,7 +97,7 @@ class Config:
         self.metabase = MetabaseConfig(
             url=os.getenv("MB_URL", ""),
             default_db_id=default_db_id,
-            map_region_uuid=os.getenv("MB_MAP_REGION_UUID") or "1c5d50ee-4389-4593-37c1-fa8d4687ff4c",
+            map_region_uuid=os.getenv("MB_MAP_REGION_UUID", ""),
         )
 
         self.ai = AIConfig(
@@ -182,7 +182,14 @@ class Config:
     def get_tenant_metabase_headers(self, tenant_id: str) -> Dict[str, str]:
         """Get Metabase API headers for a specific tenant using its api_key from tenant config."""
         tenant_config = self.get_tenant_config(tenant_id)
-        return {"x-api-key": tenant_config.get("api_key", "")}
+        api_key = tenant_config.get("api_key", "")
+        if not api_key:
+            raise ValueError(
+                f"Metabase api_key is not configured for tenant '{tenant_id}'. "
+                "For local development add it to tenant_config.local.json; "
+                "in OpenShift check the [env]-unity-ai-tenant-config secret."
+            )
+        return {"x-api-key": api_key}
 
     @property
     def metabase_headers(self) -> Dict[str, str]:

--- a/applications/Unity.AI.Reporting.Backend/src/config.py
+++ b/applications/Unity.AI.Reporting.Backend/src/config.py
@@ -11,6 +11,8 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+DEFAULT_TENANT = "Default Grants Program"
+
 
 @dataclass
 class DatabaseConfig:
@@ -139,8 +141,8 @@ class Config:
             try:
                 with open(config_file, 'r') as f:
                     mappings = json.load(f)
-                    if "default" not in mappings.keys():
-                        mappings = {"default": mappings}
+                    if DEFAULT_TENANT not in mappings.keys():
+                        mappings = {DEFAULT_TENANT: mappings}
 
                 print(f"Loaded tenant mappings from {config_file}: {mappings}")
                 return mappings
@@ -150,7 +152,7 @@ class Config:
         # Fallback to hardcoded defaults if no config file found
         print("No tenant_config.json found, using hardcoded defaults")
         return {
-            "default": {
+            DEFAULT_TENANT: {
                 "db_id": 5,
                 "collection_id": 16,
                 "schema_types": ["public"]
@@ -159,7 +161,7 @@ class Config:
     
     def get_tenant_config(self, tenant_id: str) -> Dict[str, Any]:
         """Get configuration for a specific tenant"""
-        return self.tenant_mappings.get(tenant_id, self.tenant_mappings["default"])
+        return self.tenant_mappings.get(tenant_id, self.tenant_mappings[DEFAULT_TENANT])
 
     def get_tenant_metabase_headers(self, tenant_id: str) -> Dict[str, str]:
         """
@@ -174,7 +176,7 @@ class Config:
     @property
     def metabase_headers(self) -> Dict[str, str]:
         """Get headers for Metabase API requests (uses default tenant)"""
-        return self.get_tenant_metabase_headers("default")
+        return self.get_tenant_metabase_headers(DEFAULT_TENANT)
 
 
 # Global config instance

--- a/applications/Unity.AI.Reporting.Backend/src/config.py
+++ b/applications/Unity.AI.Reporting.Backend/src/config.py
@@ -38,7 +38,7 @@ class MetabaseConfig:
     url: str
     api_key: str
     embed_secret: str
-    default_db_id: int = 3
+    default_db_id: int = 5
     map_region_uuid: str = "1c5d50ee-4389-4593-37c1-fa8d4687ff4c"
     
 
@@ -84,6 +84,10 @@ class Config:
     """Central configuration manager"""
     
     def __init__(self):
+        # Load tenant mappings first so db_id can be derived from them
+        self.tenant_mappings = self._load_tenant_mappings()
+        default_db_id = self.tenant_mappings.get(DEFAULT_TENANT, {}).get("db_id", 5)
+
         self.database = DatabaseConfig(
             host=os.getenv("DB_HOST", "localhost"),
             port="5432",
@@ -91,20 +95,20 @@ class Config:
             user=os.getenv("DB_USER", "unity_user"),
             password=os.getenv("DB_PASSWORD", "unity_pass")
         )
-        
+
         self.metabase = MetabaseConfig(
             url=os.getenv("MB_URL", ""),
             api_key=os.getenv("METABASE_KEY", ""),
             embed_secret=os.getenv("MB_EMBED_SECRET", ""),
-            default_db_id=int(os.getenv("MB_EMBED_ID", "3")),
-            map_region_uuid=os.getenv("MB_MAP_REGION_UUID", "1c5d50ee-4389-4593-37c1-fa8d4687ff4c"),
+            default_db_id=default_db_id,
+            map_region_uuid=os.getenv("MB_MAP_REGION_UUID") or "1c5d50ee-4389-4593-37c1-fa8d4687ff4c",
         )
-        
+
         self.ai = AIConfig(
             azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT", ""),
             azure_api_key=os.getenv("AZURE_OPENAI_API_KEY", ""),
         )
-        
+
         flask_env = os.getenv("FLASK_ENV", "development")
         self.app = AppConfig(
             flask_env=flask_env,
@@ -121,9 +125,6 @@ class Config:
             llm_judge_score_threshold=float(os.getenv("LLM_JUDGE_SCORE_THRESHOLD", "8.0")),
             preview_row_limit=int(os.getenv("PREVIEW_ROW_LIMIT", "1000")),
         )
-        
-        # Tenant configuration - extensible for different use cases
-        self.tenant_mappings = self._load_tenant_mappings()
     
     def _load_tenant_mappings(self) -> Dict[str, Dict[str, Any]]:
         """

--- a/applications/Unity.AI.Reporting.Backend/src/config.py
+++ b/applications/Unity.AI.Reporting.Backend/src/config.py
@@ -36,7 +36,6 @@ class DatabaseConfig:
 class MetabaseConfig:
     """Metabase API configuration"""
     url: str
-    embed_secret: str
     default_db_id: int
     map_region_uuid: str
     
@@ -97,7 +96,6 @@ class Config:
 
         self.metabase = MetabaseConfig(
             url=os.getenv("MB_URL", ""),
-            embed_secret=os.getenv("MB_EMBED_SECRET", ""),
             default_db_id=default_db_id,
             map_region_uuid=os.getenv("MB_MAP_REGION_UUID") or "1c5d50ee-4389-4593-37c1-fa8d4687ff4c",
         )

--- a/applications/Unity.AI.Reporting.Backend/src/embeddings.py
+++ b/applications/Unity.AI.Reporting.Backend/src/embeddings.py
@@ -253,8 +253,6 @@ class EmbeddingManager:
         # Default schema types if not specified
         if schema_types is None:
             schema_types = ['public']
-            if config.app.embed_worksheets:
-                schema_types.append('custom')
         
         # Purge existing embeddings for this db_id
         db_manager.purge_embeddings(db_id, config.app.collection_name)
@@ -296,7 +294,8 @@ class EmbeddingManager:
         ) or []
 
     def search_similar_schemas(self, query: str, db_id: int,
-                             k_public: int = 4) -> List[Document]:
+                             k_public: int = 4,
+                             tenant_id: Optional[str] = None) -> List[Document]:
         """
         Search for similar schemas based on query with automatic retry on connection errors.
 
@@ -304,6 +303,7 @@ class EmbeddingManager:
             query: Natural language query
             db_id: Database ID to filter by
             k_public: Number of public schemas to retrieve
+            tenant_id: Optional tenant ID to determine which schema types to include
 
         Returns:
             List of similar schema documents
@@ -322,20 +322,22 @@ class EmbeddingManager:
                 retrieved.extend(public_results)
 
         # Get ALL custom/worksheet schemas — don't rely on top-k similarity
-        if config.app.embed_worksheets:
+        tenant_schema_types = config.get_tenant_config(tenant_id or "default").get("schema_types", ["public"])
+        if "custom" in tenant_schema_types:
             custom_results = self._get_all_custom_schemas(query, db_id)
             if custom_results:
                 retrieved.extend(custom_results)
 
         return retrieved
-    
+
     def embed_query(self, query: str) -> list:
         """Return raw embedding vector for a single query string."""
         return self.embedding_model.embed_query(query)
 
-    def get_formatted_schemas(self, query: str, db_id: int) -> str:
+    def get_formatted_schemas(self, query: str, db_id: int,
+                              tenant_id: Optional[str] = None) -> str:
         """Get formatted schema text for prompt, grouped by section with headers."""
-        schemas = self.search_similar_schemas(query, db_id)
+        schemas = self.search_similar_schemas(query, db_id, tenant_id=tenant_id)
 
         section_headers = {
             "public": "=== PUBLIC TABLES ===",

--- a/applications/Unity.AI.Reporting.Backend/src/embeddings.py
+++ b/applications/Unity.AI.Reporting.Backend/src/embeddings.py
@@ -9,7 +9,7 @@ from langchain_core.documents import Document
 from langchain_openai import AzureOpenAIEmbeddings
 from pydantic import SecretStr
 from langchain_postgres import PGVector
-from config import config
+from config import config, DEFAULT_TENANT
 from database import db_manager
 from metabase import metabase_client
 
@@ -322,7 +322,7 @@ class EmbeddingManager:
                 retrieved.extend(public_results)
 
         # Get ALL custom/worksheet schemas — don't rely on top-k similarity
-        tenant_schema_types = config.get_tenant_config(tenant_id or "default").get("schema_types", ["public"])
+        tenant_schema_types = config.get_tenant_config(tenant_id or DEFAULT_TENANT).get("schema_types", ["public"])
         if "custom" in tenant_schema_types:
             custom_results = self._get_all_custom_schemas(query, db_id)
             if custom_results:

--- a/applications/Unity.AI.Reporting.Backend/src/sql_generator.py
+++ b/applications/Unity.AI.Reporting.Backend/src/sql_generator.py
@@ -341,7 +341,7 @@ class SQLGenerator:
             return sql, metadata, {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}, None
 
         # Get relevant schemas
-        schemas = self.embeddings.get_formatted_schemas(question, db_id)
+        schemas = self.embeddings.get_formatted_schemas(question, db_id, tenant_id=tenant_id)
         if not schemas:
             logger.error(f"No schemas found for db_id={db_id}. Embeddings may not have been generated yet.")
             return None, None, None, None

--- a/applications/Unity.AI.Reporting.Backend/src/tenant_config.json
+++ b/applications/Unity.AI.Reporting.Backend/src/tenant_config.json
@@ -1,5 +1,5 @@
 {
-  "default": {
+  "Default Grants Program": {
     "db_id": 5,
     "collection_id": 16,
     "schema_types": ["public", "custom"],
@@ -8,12 +8,6 @@
   "REDIP": {
     "db_id": 9,
     "collection_id": 93,
-    "schema_types": ["public", "custom"],
-    "api_key": ""
-  },
-  "Default Grants Program": {
-    "db_id": 5,
-    "collection_id": 16,
     "schema_types": ["public", "custom"],
     "api_key": ""
   }

--- a/applications/docker-compose.override.yml.example
+++ b/applications/docker-compose.override.yml.example
@@ -1,0 +1,11 @@
+# Local development overrides for docker-compose.yml.
+# Copy this file to docker-compose.override.yml (gitignored) to activate.
+# Docker Compose merges it automatically — no flags needed.
+#
+# Primary use: mount tenant_config.local.json so local secrets (e.g. api_key)
+# are available inside the container without being committed to the repo.
+
+services:
+  reporting:
+    volumes:
+      - ./Unity.AI.Reporting.Backend/src/tenant_config.local.json:/app/backend/src/tenant_config.local.json

--- a/applications/docker-compose.yml
+++ b/applications/docker-compose.yml
@@ -45,10 +45,11 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       - ORIGIN_URL=${ORIGIN_URL}
 
-      # Metabase config (secrets + env-specific base URL)
+      # Metabase config (secrets + env-specific base URL and UUIDs)
       - METABASE_KEY=${METABASE_KEY}
       - MB_EMBED_SECRET=${MB_EMBED_SECRET}
       - MB_URL=${MB_URL}
+      - MB_MAP_REGION_UUID=${MB_MAP_REGION_UUID}
 
       # Feature flags
       - EMBED_WORKSHEETS=${EMBED_WORKSHEETS:-true}

--- a/applications/docker-compose.yml
+++ b/applications/docker-compose.yml
@@ -46,7 +46,6 @@ services:
       - ORIGIN_URL=${ORIGIN_URL}
 
       # Metabase config (secrets + env-specific base URL and UUIDs)
-      - MB_EMBED_SECRET=${MB_EMBED_SECRET}
       - MB_URL=${MB_URL}
       - MB_MAP_REGION_UUID=${MB_MAP_REGION_UUID}
 

--- a/applications/docker-compose.yml
+++ b/applications/docker-compose.yml
@@ -51,9 +51,6 @@ services:
       - MB_URL=${MB_URL}
       - MB_MAP_REGION_UUID=${MB_MAP_REGION_UUID}
 
-      # Feature flags
-      - EMBED_WORKSHEETS=${EMBED_WORKSHEETS:-true}
-
       # Database config
       - DB_HOST=postgres
       - DB_NAME=${DB_NAME:-unity_ai}

--- a/applications/docker-compose.yml
+++ b/applications/docker-compose.yml
@@ -46,7 +46,6 @@ services:
       - ORIGIN_URL=${ORIGIN_URL}
 
       # Metabase config (secrets + env-specific base URL and UUIDs)
-      - METABASE_KEY=${METABASE_KEY}
       - MB_EMBED_SECRET=${MB_EMBED_SECRET}
       - MB_URL=${MB_URL}
       - MB_MAP_REGION_UUID=${MB_MAP_REGION_UUID}

--- a/documentation/unity-ai-reporting-environment-specific-configuration.md
+++ b/documentation/unity-ai-reporting-environment-specific-configuration.md
@@ -2,322 +2,213 @@
 
 ## Overview
 
-The Unity AI platform requires environment-specific configuration for different deployment environments (dev, test, uat, prod). This guide provides a comprehensive reference for all required environment variables and their proper configuration.
+The Unity AI platform uses two sources of runtime configuration:
 
-**GitOps Repository Structure:**
-```
-tenant-gitops-d18498/manifests/uai/overlays/
-├── dev/     # d18498-dev namespace
-├── test/    # d18498-test namespace  
-├── uat/     # d18498-test namespace (UAT shares test namespace)
-└── prod/    # d18498-prod namespace
-```
+1. **Environment variables** — injected via OpenShift Secrets and ConfigMaps (or `.env` locally)
+2. **Tenant config** — a JSON file (`tenant_config.json`) that maps tenants to Metabase databases and schema settings, overridden per environment via the `[env]-unity-ai-tenant-config` OpenShift Secret
 
-## Complete Environment Variables Reference
+Non-sensitive config (deployment names, model versions, database port) is hardcoded in `config.py` and does not require environment variables.
 
-### 🔴 Critical Variables (No Defaults - Must Be Set)
+---
+
+## Environment Variables Reference
+
+### 🔴 Secrets (OpenShift Secret — no defaults, must be set)
+
+| Variable | Purpose | Example |
+|----------|---------|---------|
+| `AZURE_OPENAI_ENDPOINT` | Azure OpenAI service endpoint | `https://d837ad-dev-econ-llm-east.openai.azure.com/` |
+| `AZURE_OPENAI_API_KEY` | Azure OpenAI API key | Environment-specific key |
+| `JWT_SECRET` | JWT signing secret (64+ chars) | `openssl rand -base64 64` |
+| `MB_EMBED_SECRET` | Metabase embedding secret | Environment-specific secret |
+| `DB_PASSWORD` | PostgreSQL password | Environment-specific password |
+
+### 🟡 ConfigMap (environment-specific, non-sensitive)
 
 | Variable | Purpose | Example Values |
 |----------|---------|----------------|
-| `AZURE_OPENAI_ENDPOINT` | Azure OpenAI service endpoint | dev: "https://d837ad-dev-econ-llm-east.openai.azure.com/" |
-| `AZURE_OPENAI_API_KEY` | Environment-specific API key | dev: "dev_key_123", prod: "prod_key_789" |
-| `AZURE_OPENAI_DEPLOYMENT` | Model deployment name | "gpt-4o-mini" or "gpt-4-32k" |
-| `AZURE_OPENAI_EMBEDDING_DEPLOYMENT` | Azure OpenAI embeddings deployment | "text-embedding-3-large" |
-| `JWT_SECRET` | JWT signing secret (must be unique per env) | Generate per env: `openssl rand -base64 64` |
-| `METABASE_KEY` | Metabase API key for integration | "mb_AjOFDhFjcM/i/..." |
-| `MB_EMBED_SECRET` | Metabase embedding secret | "548ca570ce8203..." |
-| `MB_URL` | Metabase instance URL | dev: "https://dev-unity-reporting.apps.silver.devops.gov.bc.ca" |
-| `MB_EMBED_ID` | Metabase database ID for queries | dev: "5", test: "3", uat: "5", prod: "3" |
-| `POSTGRES_PASSWORD` | Database password | Environment-specific secure password |
+| `MB_URL` | Metabase instance base URL | `https://dev-unity-reporting.apps.silver.devops.gov.bc.ca` |
+| `MB_MAP_REGION_UUID` | Metabase UUID for the Regional Districts boundary layer | Differs per Metabase instance |
+| `ORIGIN_URL` | Comma-separated allowed iframe parent origins | `https://dev.example.com` |
+| `FLASK_ENV` | Flask environment mode | `development`, `production` |
+| `DB_HOST` | PostgreSQL host | `[env]-unity-ai-postgres` |
+| `DB_NAME` | PostgreSQL database name | `unity_ai` |
+| `DB_USER` | PostgreSQL username | `unity_user` |
 
-### 🟡 Important Variables (Has Defaults - Environment-Specific)
+### 🔧 Build-time (baked into Docker image)
 
-| Variable | Purpose | Default Value | Environment-Specific Values |
-|----------|---------|---------------|----------------------------|
-| `FLASK_ENV` | Flask environment mode | "development" | dev=development, test=test, uat=staging, prod=production |
-| `POSTGRES_DB` | Database name | "unity_ai" | Different per environment |
-| `POSTGRES_USER` | Database username | "unity_user" | Different per environment |
-| `DEFAULT_EMBED_DB_ID` | Default tenant database mapping | "5" | dev: "5", test: "3", uat: "5", prod: "3" |
-| `AZURE_OPENAI_API_VERSION` | Azure OpenAI API version | "2024-02-01" | Could vary per environment |
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `UAI_BUILD_VERSION` | Application version | `0.0.0` |
+| `UAI_BUILD_REVISION` | Git commit hash | `0000000` |
+| `UAI_TARGET_ENVIRONMENT` | Target environment label | `Development` |
 
-### 🟢 Optional Variables (Has Defaults)
+### Hardcoded in `config.py` (no env var needed)
 
-| Variable | Purpose | Default Value |
-|----------|---------|---------------|
-| `AI_MODEL` | Primary AI model | "gpt-4o-mini" |
-| `EMBEDDING_MODEL` | Embedding model | "text-embedding-3-large" |
-| `EMBED_WORKSHEETS` | Enable worksheet embedding | "true" |
-| `DB_HOST` | Database host | "localhost" |
-| `DB_PORT` | Database port | "5432" |
-| `DB_NAME` | Database name (fallback) | "unity_ai" |
-| `DB_USER` | Database user (fallback) | "unity_user" |
-| `DB_PASSWORD` | Database password (fallback) | "unity_pass" |
+| Setting | Value |
+|---------|-------|
+| Azure OpenAI deployment | `gpt-5-mini` |
+| Azure OpenAI embedding deployment | `text-embedding-3-large` |
+| Azure OpenAI API version | `2024-10-21` |
+| Database port | `5432` |
 
-### 🔧 Build-Time Variables (Baked into Docker Image)
+---
 
-| Variable | Purpose | Default | Usage |
-|----------|---------|---------|-------|
-| `UAI_BUILD_VERSION` | Application version | "0.0.0" | Frontend build-info.json |
-| `UAI_BUILD_REVISION` | Git commit hash | "0000000" | Frontend build-info.json |
-| `UAI_TARGET_ENVIRONMENT` | Target environment | "Development" | Frontend build-info.json |
+## Tenant Configuration
 
-### 🔵 Legacy/Unused Variables (Optional)
+The Metabase API key and per-tenant database mappings are **not** environment variables. They live in a JSON file that is mounted into the container as a secret.
 
-| Variable | Purpose | Default Value | Status |
-|----------|---------|---------------|--------|
-| `COMPLETION_ENDPOINT` | Legacy OpenAI endpoint | "" | Optional fallback |
-| `COMPLETION_KEY` | Legacy OpenAI key | "" | Optional fallback |
+### Structure
 
-## Actual GitOps Environment Configuration
-
-### Current Environment Structure
-
-Based on `tenant-gitops-d18498/manifests/uai/overlays/`:
-
-| Environment | Namespace | FLASK_ENV | DEFAULT_EMBED_DB_ID | MB_URL |
-|-------------|-----------|-----------|---------------------|---------|
-| **dev** | d18498-dev | development | "5" | dev-unity-reporting.apps.silver.devops.gov.bc.ca |
-| **test** | d18498-test | test | "3" | test-unity-reporting.apps.silver.devops.gov.bc.ca |
-| **uat** | d18498-test | staging | "5" | uat-unity-reporting.apps.silver.devops.gov.bc.ca |
-| **prod** | d18498-prod | production | "3" | unity-reporting.apps.silver.devops.gov.bc.ca |
-
-## Environment Configuration Templates
-
-### Development Environment
-
-```bash
-# 🔴 Critical (Must Set)
-AZURE_OPENAI_ENDPOINT="https://d837ad-dev-econ-llm-east.openai.azure.com/"
-AZURE_OPENAI_API_KEY="dev-api-key-here"
-AZURE_OPENAI_DEPLOYMENT="gpt-4o-mini"
-AZURE_OPENAI_EMBEDDING_DEPLOYMENT="text-embedding-3-large"
-JWT_SECRET="dev-jwt-secret-64-chars-minimum"
-METABASE_KEY="dev-metabase-api-key"
-MB_EMBED_SECRET="dev-metabase-embed-secret"
-MB_URL="https://dev-unity-reporting.apps.silver.devops.gov.bc.ca"
-MB_EMBED_ID="5"
-POSTGRES_PASSWORD="dev-postgres-password"
-
-# 🟡 Environment-Specific
-FLASK_ENV="development"
-POSTGRES_DB="unity_ai_dev"
-POSTGRES_USER="dev_user"
-DEFAULT_EMBED_DB_ID="5"
-AZURE_OPENAI_API_VERSION="2024-02-01"
-
-# 🟢 Optional (Has Defaults)
-AI_MODEL="gpt-4o-mini"
-EMBEDDING_MODEL="text-embedding-3-large"
-EMBED_WORKSHEETS="true"
-DB_HOST="postgres"
-DB_PORT="5432"
+```json
+{
+  "Default Grants Program": {
+    "db_id": 5,
+    "collection_id": 16,
+    "schema_types": ["public", "custom"],
+    "api_key": "mb_your_metabase_api_key_here"
+  },
+  "REDIP": {
+    "db_id": 9,
+    "collection_id": 93,
+    "schema_types": ["public", "custom"],
+    "api_key": "mb_your_metabase_api_key_here"
+  }
+}
 ```
 
-### Test Environment
+### OpenShift
 
-```bash
-# 🔴 Critical (Must Set) - Different from dev
-AZURE_OPENAI_ENDPOINT="https://d837ad-test-econ-llm-east.openai.azure.com/"
-AZURE_OPENAI_API_KEY="test-api-key-here"
-AZURE_OPENAI_DEPLOYMENT="gpt-4o-mini"
-AZURE_OPENAI_EMBEDDING_DEPLOYMENT="text-embedding-3-large"
-JWT_SECRET="test-jwt-secret-64-chars-minimum"
-METABASE_KEY="test-metabase-api-key"
-MB_EMBED_SECRET="test-metabase-embed-secret"
-MB_URL="https://test-unity-reporting.apps.silver.devops.gov.bc.ca"
-MB_EMBED_ID="3"
-POSTGRES_PASSWORD="test-postgres-password"
+Each environment has an `[env]-unity-ai-tenant-config` Secret whose value is mounted over the committed `tenant_config.json` at `/app/backend/src/tenant_config.json`. This is where `api_key` and environment-specific `db_id`/`collection_id` values are set.
 
-# 🟡 Environment-Specific
-FLASK_ENV="test"
-POSTGRES_DB="unity_ai_test"
-POSTGRES_USER="test_user"
-DEFAULT_EMBED_DB_ID="3"
+### Local development
+
+Create `applications/Unity.AI.Reporting.Backend/src/tenant_config.local.json` (gitignored). The app merges it over `tenant_config.json` at startup — only include the fields you want to override:
+
+```json
+{
+  "Default Grants Program": { "api_key": "mb_your_local_key_here" },
+  "REDIP": { "api_key": "mb_your_local_key_here" }
+}
 ```
 
-### UAT Environment
+For Docker Compose, copy `docker-compose.override.yml.example` to `docker-compose.override.yml` (also gitignored) to mount the file into the container.
 
-```bash
-# 🔴 Critical (Must Set) - Different from dev/test
-AZURE_OPENAI_ENDPOINT="https://d837ad-uat-econ-llm-east.openai.azure.com/"
-AZURE_OPENAI_API_KEY="uat-api-key-here"
-AZURE_OPENAI_DEPLOYMENT="gpt-4o-mini"
-AZURE_OPENAI_EMBEDDING_DEPLOYMENT="text-embedding-3-large"
-JWT_SECRET="uat-jwt-secret-64-chars-minimum"
-METABASE_KEY="uat-metabase-api-key"
-MB_EMBED_SECRET="uat-metabase-embed-secret"
-MB_URL="https://uat-unity-reporting.apps.silver.devops.gov.bc.ca"
-MB_EMBED_ID="5"
-POSTGRES_PASSWORD="uat-postgres-password"
+---
 
-# 🟡 Environment-Specific
-FLASK_ENV="staging"
-POSTGRES_DB="unity_ai_uat"
-POSTGRES_USER="uat_user"
-DEFAULT_EMBED_DB_ID="5"
-```
+## OpenShift ConfigMap / Secret Examples
 
-### Production Environment
-
-```bash
-# 🔴 Critical (Must Set) - Different from dev/test/uat
-AZURE_OPENAI_ENDPOINT="https://d837ad-prod-econ-llm-east.openai.azure.com/"
-AZURE_OPENAI_API_KEY="prod-api-key-here"
-AZURE_OPENAI_DEPLOYMENT="gpt-4-32k"
-AZURE_OPENAI_EMBEDDING_DEPLOYMENT="text-embedding-3-large"
-JWT_SECRET="prod-jwt-secret-64-chars-minimum"
-METABASE_KEY="prod-metabase-api-key"
-MB_EMBED_SECRET="prod-metabase-embed-secret"
-MB_URL="https://unity-reporting.apps.silver.devops.gov.bc.ca"
-MB_EMBED_ID="3"
-POSTGRES_PASSWORD="prod-postgres-password"
-
-# 🟡 Environment-Specific
-FLASK_ENV="production"
-POSTGRES_DB="unity_ai_prod"
-POSTGRES_USER="prod_user"
-DEFAULT_EMBED_DB_ID="3"
-AI_MODEL="gpt-4-32k"
-```
-
-## GitOps Implementation Examples
-
-### ConfigMap Example (From GitOps Overlays)
-
-```yaml
-# From overlays/dev/patches/environment-patches.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: unity-ai-reporting
-data:
-  FLASK_ENV: "development"
-  DEFAULT_EMBED_DB_ID: "5"
-  MB_URL: "https://dev-unity-reporting.apps.silver.devops.gov.bc.ca"
-```
-
-### Secret Example (Critical Variables)
+### Secret
 
 ```yaml
 apiVersion: v1
 kind: Secret
 metadata:
-  name: unity-ai-secrets
+  name: dev-unity-ai-secrets
   namespace: d18498-dev
 type: Opaque
 stringData:
-  # Critical secrets (no defaults)
   AZURE_OPENAI_ENDPOINT: "https://d837ad-dev-econ-llm-east.openai.azure.com/"
-  AZURE_OPENAI_API_KEY: "your-dev-api-key-here"
-  JWT_SECRET: "your-64-char-jwt-secret-here"
-  METABASE_KEY: "your-dev-metabase-key-here"
-  MB_EMBED_SECRET: "your-dev-embed-secret-here"
-  POSTGRES_PASSWORD: "your-dev-db-password"
+  AZURE_OPENAI_API_KEY: "your-dev-api-key"
+  JWT_SECRET: "your-64-char-jwt-secret"
+  MB_EMBED_SECRET: "your-dev-embed-secret"
+  DB_PASSWORD: "your-dev-db-password"
 ```
 
-### StatefulSet Environment Configuration (From GitOps)
+### Tenant Config Secret
 
 ```yaml
-# From overlays/*/patches/environment-patches.yaml
-apiVersion: apps/v1
-kind: StatefulSet
+apiVersion: v1
+kind: Secret
 metadata:
-  name: unity-ai-reporting
-spec:
-  replicas: 1  # dev=1, test=3, uat=3, prod=varies
-  template:
-    spec:
-      containers:
-      - name: unity-ai-reporting
-        image: image-registry.openshift-image-registry.svc:5000/d18498-dev/dev-unity-ai-reporting:latest
-        env:
-        - name: FLASK_ENV
-          valueFrom:
-            configMapKeyRef:
-              name: dev-unity-ai-reporting
-              key: FLASK_ENV
-        - name: AZURE_OPENAI_ENDPOINT
-          valueFrom:
-            secretKeyRef:
-              name: dev-unity-ai-secrets
-              key: AZURE_OPENAI_ENDPOINT
-        - name: DEFAULT_EMBED_DB_ID
-          valueFrom:
-            configMapKeyRef:
-              name: dev-unity-ai-reporting
-              key: DEFAULT_EMBED_DB_ID
-        - name: MB_EMBED_ID
-          valueFrom:
-            configMapKeyRef:
-              name: dev-unity-ai-reporting
-              key: DEFAULT_EMBED_DB_ID  # Note: MB_EMBED_ID uses same value as DEFAULT_EMBED_DB_ID
-        # ... (all other environment variables follow this pattern)
+  name: dev-unity-ai-tenant-config
+  namespace: d18498-dev
+type: Opaque
+stringData:
+  tenant_config.json: |
+    {
+      "Default Grants Program": {
+        "db_id": 5,
+        "collection_id": 16,
+        "schema_types": ["public", "custom"],
+        "api_key": "mb_your_dev_metabase_api_key"
+      },
+      "REDIP": {
+        "db_id": 9,
+        "collection_id": 93,
+        "schema_types": ["public", "custom"],
+        "api_key": "mb_your_dev_metabase_api_key"
+      }
+    }
 ```
 
-## Key Insights from GitOps Configuration
+### ConfigMap
 
-### Important Notes:
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dev-unity-ai-reporting
+  namespace: d18498-dev
+data:
+  FLASK_ENV: "development"
+  MB_URL: "https://dev-unity-reporting.apps.silver.devops.gov.bc.ca"
+  MB_MAP_REGION_UUID: "your-regional-districts-uuid"
+  ORIGIN_URL: "https://dev-grants.example.com"
+  DB_HOST: "dev-unity-ai-postgres"
+  DB_NAME: "unity_ai"
+  DB_USER: "unity_user"
+```
 
-1. **MB_EMBED_ID Configuration**: In the actual GitOps setup, `MB_EMBED_ID` is set to the same value as `DEFAULT_EMBED_DB_ID`
-2. **Environment-Specific Replicas**: 
-   - Dev: 1 replica
-   - Test: 3 replicas  
-   - UAT: 3 replicas
-   - Prod: varies
-3. **Namespace Sharing**: UAT shares the d18498-test namespace with Test environment
-4. **Image Tagging**: Different environments use different image tags (latest vs stable)
+---
 
-## Configuration Validation
+## GitOps Repository Structure
 
-### Test Database Connectivity
-After configuring, verify the backend can connect:
+```
+tenant-gitops-d18498/manifests/uai/overlays/
+├── dev/     # d18498-dev namespace
+├── test/    # d18498-test namespace
+├── uat/     # d18498-test namespace (shares test namespace)
+└── prod/    # d18498-prod namespace
+```
+
+---
+
+## Determining `db_id` Values
+
+1. Log into the environment's Metabase instance
+2. Go to Settings → Admin → Databases
+3. Note the database ID from the URL or database list
+
+Or via API (using the `api_key` from tenant config):
 
 ```bash
-# Check application logs
-oc logs statefulset/dev-unity-ai-reporting -n d18498-dev
-
-# Look for successful Metabase API calls
-# Should see successful responses from /api/database/{MB_EMBED_ID}/metadata
+curl -H "x-api-key: YOUR_METABASE_API_KEY" \
+  https://your-metabase-url/api/database
 ```
 
-### How to Determine Database IDs
-
-1. **Check Metabase Admin Interface**:
-   - Log into your environment's Metabase instance
-   - Go to Settings → Admin → Databases
-   - Note the database ID number in the URL or database list
-
-2. **API Query**:
-   ```bash
-   curl -H "x-api-key: YOUR_METABASE_KEY" \
-     https://your-metabase-url/api/database
-   ```
+---
 
 ## Common Issues
 
-### Issue: Application fails with "database not found"
-**Solution**: Verify `MB_EMBED_ID` matches an actual database in your Metabase instance
+### API calls fail with authentication errors
+Verify the `api_key` in the tenant config secret has access to the Metabase instance.
 
-### Issue: Tenant mapping uses wrong database
-**Solution**: Ensure `DEFAULT_EMBED_DB_ID` is set correctly for your environment
+### Application fails with "database not found"
+Verify `db_id` in the tenant config matches an actual database in the environment's Metabase instance.
 
-### Issue: API calls fail with authentication errors
-**Solution**: Verify `METABASE_KEY` has access to the specified database ID
+### JWT authentication fails
+Ensure `JWT_SECRET` is set and is at least 64 characters long.
 
-### Issue: JWT authentication fails
-**Solution**: Ensure `JWT_SECRET` is set and is at least 64 characters long
+### Map visualization shows wrong region boundaries
+Check `MB_MAP_REGION_UUID` — it must match the Regional Districts layer UUID in that Metabase instance.
+
+---
 
 ## Security Best Practices
 
-1. **Never commit secrets to Git** - Use External Secrets Operator or manual secret creation
-2. **Environment isolation** - Each environment should have completely separate credentials
-3. **Secret rotation** - Regularly rotate JWT secrets, API keys, and database passwords (use `openssl rand -base64 64` for JWT secrets)
-4. **Least privilege** - Database users should only have required permissions
-5. **Network policies** - Restrict pod-to-pod communication where possible
-6. **Environment-specific API keys** - Use different Azure OpenAI keys per environment to prevent cross-environment data leaks
-7. **Validate critical variables** - Application will fail to start if critical variables (marked 🔴) are missing
-8. **Build-time vs Runtime** - Build arguments are baked into images, runtime environment variables are provided during deployment
-
-## Local Development
-
-For local development using docker-compose, the `.env` file contains default values that will be overridden by environment-specific values in OpenShift deployments.
+1. Never commit secrets to Git — use the `[env]-unity-ai-tenant-config` Secret and `[env]-unity-ai-secrets` for all sensitive values
+2. Each environment must have completely separate credentials
+3. Rotate JWT secrets, API keys, and database passwords regularly (`openssl rand -base64 64` for JWT)
+4. Database users should have only the required permissions
+5. Use different Azure OpenAI keys per environment to prevent cross-environment data leaks

--- a/documentation/unity-ai-reporting-environment-specific-configuration.md
+++ b/documentation/unity-ai-reporting-environment-specific-configuration.md
@@ -20,7 +20,6 @@ Non-sensitive config (deployment names, model versions, database port) is hardco
 | `AZURE_OPENAI_ENDPOINT` | Azure OpenAI service endpoint | `https://d837ad-dev-econ-llm-east.openai.azure.com/` |
 | `AZURE_OPENAI_API_KEY` | Azure OpenAI API key | Environment-specific key |
 | `JWT_SECRET` | JWT signing secret (64+ chars) | `openssl rand -base64 64` |
-| `MB_EMBED_SECRET` | Metabase embedding secret | Environment-specific secret |
 | `DB_PASSWORD` | PostgreSQL password | Environment-specific password |
 
 ### 🟡 ConfigMap (environment-specific, non-sensitive)
@@ -111,7 +110,6 @@ stringData:
   AZURE_OPENAI_ENDPOINT: "https://d837ad-dev-econ-llm-east.openai.azure.com/"
   AZURE_OPENAI_API_KEY: "your-dev-api-key"
   JWT_SECRET: "your-64-char-jwt-secret"
-  MB_EMBED_SECRET: "your-dev-embed-secret"
   DB_PASSWORD: "your-dev-db-password"
 ```
 


### PR DESCRIPTION
- Added back Metabase Map region UUID
- Removed `EMBED_WORKSHEETS` and `MB_EMBED_SECRET`
- Merged `METABASE_KEY` env var with config `api_key`
- Replaced default tenant with Default Grants Program
- Removed hardcoded default ("3") `db_id`
- Fail fast on missing `api_key`
- Updated documents